### PR TITLE
Update member-join and node-started for new ASM

### DIFF
--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -22,7 +22,7 @@ setup() {
 }
 
 _notify_appliance() {
-    local port address
+    local port address appliance_type
     port="$1"
     address="$2"
     appliance_type="$3"

--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -25,8 +25,9 @@ _notify_appliance() {
     local port address
     port="$1"
     address="$2"
+    appliance_type="$3"
     files_load_config config config/cluster
-    cat <<JSON | webapi_post "${address}"/clusters/register
+    cat <<JSON | webapi_post "${address}"/${appliance_type}/register
 {
   "cluster": {
     "name": "${cw_CLUSTER_name}",
@@ -104,7 +105,7 @@ main() {
         done
         if [[ "${cw_INSTANCE_tag_APPLIANCE_ROLES}" == *":storage:"* && "${storage_roles}" == *":master:"* ]]; then
             echo "Adding Storage Manager master node: ${cw_MEMBER_name} (${cw_MEMBER_ip}:${storage_daemon_port:-25268})"
-            _notify_appliance "${cw_MEMBER_ip}" "${storage_daemon_port:-25268}"
+            _notify_appliance "${cw_MEMBER_ip}" "${storage_daemon_port:-25268}" "storage"
         fi
         if [[ "${cw_INSTANCE_tag_APPLIANCE_ROLES}" == *":access:"* && "${access_roles}" == *":master:"* ]]; then
             echo "Adding Access Manager master node: ${cw_MEMBER_name} (${cw_MEMBER_ip}:${access_daemon_port:-25269})"

--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -21,6 +21,23 @@ setup() {
     kernel_load
 }
 
+_notify_appliance() {
+    local port address
+    port="$1"
+    address="$2"
+    files_load_config config config/cluster
+    cat <<JSON | webapi_post "${address}"/clusters/register
+{
+  "cluster": {
+    "name": "${cw_CLUSTER_name}",
+    "ip": "${address}",
+    "auth_port": ${port},
+    "ssl": true,
+  }
+}
+JSON
+}
+
 _add_storage_master_node() {
     local addr port
     addr="$1"
@@ -36,23 +53,7 @@ _add_storage_master_node() {
 :endpoints:
 - "${addr}:${port}"
 EOF
-	cat <<EOF > "${cw_APPLIANCES_storage_MANAGER_ROOT}"/webapp/config/storagemanager.yml
----
-:auth:
-  :address: "${addr}:${port}"
-  :ssl: true
-:ssl:
-  :root: /opt/alces-storage-manager/etc/ssl/client
-  :certificate: cert.pem
-  :key: key.pem
-  :verify: false
-  :ca: alces-ca_crt.pem
-EOF
-	if distro_restart_service alces-storage-manager; then
-            echo "Alces Storage Manager service restarted"
-	else
-            echo "Unable to restart Alces Storage Manager service"
-	fi
+        _notify_appliance "${port}" "${addr}"
     fi
 }
 
@@ -103,7 +104,7 @@ main() {
         done
         if [[ "${cw_INSTANCE_tag_APPLIANCE_ROLES}" == *":storage:"* && "${storage_roles}" == *":master:"* ]]; then
             echo "Adding Storage Manager master node: ${cw_MEMBER_name} (${cw_MEMBER_ip}:${storage_daemon_port:-25268})"
-            _add_storage_master_node "${cw_MEMBER_ip}" "${storage_daemon_port:-25268}"
+            _notify_appliance "${cw_MEMBER_ip}" "${storage_daemon_port:-25268}"
         fi
         if [[ "${cw_INSTANCE_tag_APPLIANCE_ROLES}" == *":access:"* && "${access_roles}" == *":master:"* ]]; then
             echo "Adding Access Manager master node: ${cw_MEMBER_name} (${cw_MEMBER_ip}:${access_daemon_port:-25269})"

--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -54,7 +54,7 @@ _add_storage_master_node() {
 :endpoints:
 - "${addr}:${port}"
 EOF
-        _notify_appliance "${port}" "${addr}"
+        _notify_appliance "${port}" "${addr}" "storage"
     fi
 }
 
@@ -105,7 +105,7 @@ main() {
         done
         if [[ "${cw_INSTANCE_tag_APPLIANCE_ROLES}" == *":storage:"* && "${storage_roles}" == *":master:"* ]]; then
             echo "Adding Storage Manager master node: ${cw_MEMBER_name} (${cw_MEMBER_ip}:${storage_daemon_port:-25268})"
-            _notify_appliance "${cw_MEMBER_ip}" "${storage_daemon_port:-25268}" "storage"
+            _add_storage_master_node "${cw_MEMBER_ip}" "${storage_daemon_port:-25268}"
         fi
         if [[ "${cw_INSTANCE_tag_APPLIANCE_ROLES}" == *":access:"* && "${access_roles}" == *":master:"* ]]; then
             echo "Adding Access Manager master node: ${cw_MEMBER_name} (${cw_MEMBER_ip}:${access_daemon_port:-25269})"

--- a/cluster-appliances/node-started
+++ b/cluster-appliances/node-started
@@ -22,7 +22,7 @@ setup() {
 }
 
 _notify_appliance() {
-    local port address
+    local port address appliance_type
     port="$1"
     address="$2"
     appliance_type="$3"

--- a/cluster-appliances/node-started
+++ b/cluster-appliances/node-started
@@ -25,8 +25,9 @@ _notify_appliance() {
     local port address
     port="$1"
     address="$2"
+    appliance_type="$3"
     files_load_config config config/cluster
-    cat <<JSON | webapi_post "${address}"/clusters/register
+    cat <<JSON | webapi_post "${address}"/"${appliance_type}"/register
 {
   "cluster": {
     "name": "${cw_CLUSTER_name}",
@@ -43,12 +44,12 @@ main() {
     files_load_config --optional cluster-appliances config/cluster-appliances
     if [[ "${cw_INSTANCE_tag_STORAGE_ROLES}" == *":master:"* ]]; then
 	if [ "${cw_APPLIANCES_storage_ADDRESS}" ]; then
-	    _notify_appliance "${cw_INSTANCE_tag_ACCESS_DAEMON_PORT:-25268}" "${cw_APPLIANCES_storage_ADDRESS}"
+	    _notify_appliance "${cw_INSTANCE_tag_ACCESS_DAEMON_PORT:-25268}" "${cw_APPLIANCES_storage_ADDRESS}" "storage"
 	fi
     fi
     if [[ "${cw_INSTANCE_tag_ACCESS_ROLES}" == *":master:"* ]]; then
 	if [ "${cw_APPLIANCES_access_ADDRESS}" ]; then
-	    _notify_appliance "${cw_INSTANCE_tag_ACCESS_DAEMON_PORT:-25269}" "${cw_APPLIANCES_access_ADDRESS}"
+	    _notify_appliance "${cw_INSTANCE_tag_ACCESS_DAEMON_PORT:-25269}" "${cw_APPLIANCES_access_ADDRESS}" "clusters"
 	fi
     fi
 }


### PR DESCRIPTION
The rewrite of ASM (at the time of writing in `develop`) includes a new API endpoint to register storage daemons and make them available through the webapp.

We agreed to use this route for both local single-cluster and remote multi-cluster modes of operation.

Previously, the former was handled by writing out a new config file for ASM. This PR causes the `member-join` handler to instead make a POST to the relevant API endpoint.

The latter case was not previously supported by ASM but was using the same handler as for AAM. This PR also parameterises the relevant function in the `node-started` handler.

Trello: https://trello.com/c/vcHLMhCC
