### PR TITLE
Enable alces-flight-www for Alces Storage Manager.

### DIFF
--- a/cluster-appliances/configure
+++ b/cluster-appliances/configure
@@ -42,11 +42,11 @@ RUBY
 _enable_alces_flight_www() {
     local role, certname
     role="$1"
-    ⁠⁠⁠⁠files_load_config config config/cluster
+    files_load_config config config/cluster
     
     certname = "${role}.${cw_CLUSTER_name}"
     
-    cat <<ENDCONF > "${cw_ROOT}"/etc/alces-flight-www.rc﻿⁠⁠⁠⁠
+    cat <<ENDCONF > "${cw_ROOT}"/etc/alces-flight-www.rc
 cw_ALCES_FLIGHT_WWW_ssl_strategy=allocate
 cw_ALCES_FLIGHT_WWW_ssl_name=${certname}
 ENDCONF

--- a/cluster-appliances/configure
+++ b/cluster-appliances/configure
@@ -39,6 +39,26 @@ write_file('cluster-appliances.rc', appliances_vars.join("\n"))
 RUBY
 }
 
+_enable_alces_flight_www() {
+    local role, certname
+    role="$1"
+    ⁠⁠⁠⁠files_load_config config config/cluster
+    
+    certname = "${role}.${cw_CLUSTER_name}"
+    
+    cat <<ENDCONF > "${cw_ROOT}"/etc/alces-flight-www.rc﻿⁠⁠⁠⁠
+cw_ALCES_FLIGHT_WWW_ssl_strategy=allocate
+cw_ALCES_FLIGHT_WWW_ssl_name=${certname}
+ENDCONF
+    
+    "${cw_ROOT}"/bin/alces service enable alces-flight-www
+    if distro_start_service clusterware-alces-flight-www; then
+        echo "Flight WWW service started"
+    else
+        echo "Unable to start Flight WWW service"
+    fi
+}
+
 _fulfil_appliance_role() {
     local role
     role="$1"
@@ -64,12 +84,7 @@ _fulfil_appliance_role() {
         fi
 
         if [ "${role}" == "storage" ]; then
-            "${cw_ROOT}"/bin/alces service enable alces-flight-www
-            if distro_start_service clusterware-alces-flight-www; then
-                echo "Flight WWW service started"
-            else
-                echo "Unable to start Flight WWW service"
-            fi
+            _enable_alces_flight_www "$role"
         fi
    fi
 }

--- a/cluster-appliances/configure
+++ b/cluster-appliances/configure
@@ -46,22 +46,31 @@ _fulfil_appliance_role() {
         "${cw_ROOT}"/bin/alces service enable appliance/alces-${role}-manager/base
         if distro_start_service alces-${role}-manager; then
             echo "Flight appliance service started: ${role}"
+        else
+            echo "Unable to start Flight appliance service: ${role}"
+        fi
+
+        if [ "${role}" == "access" ]; then
             if distro_start_service alces-${role}-manager-proxy; then
                 echo "Flight appliance proxy service started: ${role}"
             else
                 echo "Unable to start Flight appliance proxy service: ${role}"
             fi
-        else
-            echo "Unable to start Flight appliance service: ${role}"
-        fi
-
-        # if [ "${role}" == "access" ]; then
         #     if distro_start_service clusterware-alces-websocket-proxy; then
         #         echo "Alces Websocket Proxy service started"
         #     else
         #         echo "Unable to start Alces Websocket Proxy"
         #     fi
-        # fi
+        fi
+
+        if [ "${role}" == "storage" ]; then
+            "${cw_ROOT}"/bin/alces service enable alces-flight-www
+            if distro_start_service alces-flight-www; then
+                echo "Flight WWW service started"
+            else
+                echo "Unable to start Flight WWW service"
+            fi
+        fi
    fi
 }
 

--- a/cluster-appliances/configure
+++ b/cluster-appliances/configure
@@ -65,7 +65,7 @@ _fulfil_appliance_role() {
 
         if [ "${role}" == "storage" ]; then
             "${cw_ROOT}"/bin/alces service enable alces-flight-www
-            if distro_start_service alces-flight-www; then
+            if distro_start_service clusterware-alces-flight-www; then
                 echo "Flight WWW service started"
             else
                 echo "Unable to start Flight WWW service"

--- a/cluster-appliances/configure
+++ b/cluster-appliances/configure
@@ -40,11 +40,11 @@ RUBY
 }
 
 _enable_alces_flight_www() {
-    local role, certname
+    local role certname
     role="$1"
     files_load_config config config/cluster
     
-    certname = "${role}.${cw_CLUSTER_name}"
+    certname="${role}.${cw_CLUSTER_name}"
     
     cat <<ENDCONF > "${cw_ROOT}"/etc/alces-flight-www.rc
 cw_ALCES_FLIGHT_WWW_ssl_strategy=allocate


### PR DESCRIPTION
This PR enables the `alces-flight-www` service with a properly provisioned SSL certificate for use by the Alces Storage Manager.
