### PR TITLE
Fix member-join with magic sleep

### DIFF
--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -28,7 +28,7 @@ _notify_appliance() {
     appliance_type="$3"
     files_load_config config config/cluster
     sleep 5
-    cat <<JSON | webapi_post https://localhost/api/v1/${appliance_type}/register --mime-type application/json -k
+    cat <<JSON | webapi_post https://localhost/api/v1/${appliance_type}/register --mimetype application/json -k
 {
   "cluster": {
     "name": "${cw_CLUSTER_name}",

--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -27,7 +27,10 @@ _notify_appliance() {
     address="$2"
     appliance_type="$3"
     files_load_config config config/cluster
-    sleep 5
+    until curl -ksf "https://localhost/api/v1/${appliance_type}/" > /dev/null; do
+        echo "Waiting for ASM webapp to become available..."
+        sleep 5
+    done
     cat <<JSON | webapi_post https://localhost/api/v1/${appliance_type}/register --mimetype application/json -k
 {
   "cluster": {

--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -27,13 +27,14 @@ _notify_appliance() {
     address="$2"
     appliance_type="$3"
     files_load_config config config/cluster
-    cat <<JSON | webapi_post https://localhost/api/v1/${appliance_type}/register -k
+    sleep 5
+    cat <<JSON | webapi_post https://localhost/api/v1/${appliance_type}/register --mime-type application/json -k
 {
   "cluster": {
     "name": "${cw_CLUSTER_name}",
     "ip": "${address}",
     "auth_port": ${port},
-    "ssl": true,
+    "ssl": true
   }
 }
 JSON


### PR DESCRIPTION
This PR fixes the `cluster-appliances` `member-join` handler to include a magic sleep, to try to ensure that the recipient webapp has fully started up before we send our POST; it also sets the `--mimetype` argument to `webapi_post` to ensure the webapp accepts the request.
