### PR TITLE
Display the correct `help`

### DIFF
--- a/cluster-customizer/libexec/customize/actions/help
+++ b/cluster-customizer/libexec/customize/actions/help
@@ -73,7 +73,7 @@ help_for_list() {
 EOF
 }
 
-help_for_list() {
+help_for_pull() {
     cat <<EOF
   SYNOPSIS:
 


### PR DESCRIPTION
Stop: 

```
[alces@login1(sir-torqueington-the-first) ~]$ alces help customize pull
/opt/clusterware/libexec/customize/actions/help: line 31: help_for_pull: command not found
```
