### PR TITLE
AAM cluster-appliances updates

### DIFF
--- a/cluster-appliances/configure
+++ b/cluster-appliances/configure
@@ -94,8 +94,13 @@ main() {
     mkdir -p "${cw_ROOT}/etc/config/cluster-appliances"
 
     files_load_config instance config/cluster
-    if [[ "${cw_INSTANCE_tag_STORAGE_ROLES}" == *":master:"* ]]; then
+
+    if [[ "${cw_INSTANCE_tag_STORAGE_ROLES}" == *":master:"* ]] ||
+      [[ "${cw_INSTANCE_tag_ACCESS_ROLES}" == *":master:"* ]]; then
         _write_configuration
+    fi
+
+    if [[ "${cw_INSTANCE_tag_STORAGE_ROLES}" == *":master:"* ]]; then
         _fulfil_endpoint_role "storage" "${cw_INSTANCE_tag_STORAGE_DAEMON_PORT:-25268}"
         if [ "${cw_APPLIANCES_storage_SKIP_DEFAULTS}" != "true" ]; then
             "${cw_ROOT}"/bin/alces storage enable posix

--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -125,14 +125,14 @@ main() {
         if [[ "${appliance_roles}" == *":storage:"* ]]; then
             appliance_url="https://storage.${cw_CLUSTER_name}.cloud.alces.network/"
             # insert cluster name into URL in config file
-            sed -i "s/_APPLIANCE_URL_/${appliance_url}/" "${dir}"/var/alces-flight-www/alces-storage-manager/config.yml
+            sed -i "s%_APPLIANCE_URL_%${appliance_url}%" "${dir}"/var/alces-flight-www/alces-storage-manager/config.yml
             "${cw_ROOT}"/libexec/share/www-add-resource "${dir}"/var/alces-flight-www/alces-storage-manager
         fi
 
         if [[ "${appliance_roles}" == *":access:"* ]]; then
             appliance_url="https://access.${cw_CLUSTER_name}.cloud.alces.network/"
             # insert cluster name into URL in config file
-            sed -i "s/_APPLIANCE_URL_/${appliance_url}/" "${dir}"/var/alces-flight-www/alces-access-manager/config.yml
+            sed -i "s%_APPLIANCE_URL_%${appliance_url}%" "${dir}"/var/alces-flight-www/alces-access-manager/config.yml
             "${cw_ROOT}"/libexec/share/www-add-resource "${dir}"/var/alces-flight-www/alces-access-manager
         fi
     fi

--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -117,23 +117,34 @@ main() {
         fi
     fi
 
-    if [[ "${cw_INSTANCE_role}" == "master" && "$(network_get_edition)" != "community" ]] && handler_is_enabled cluster-www; then
+    if [[ "${cw_INSTANCE_role}" == "master" && "$(network_get_edition)" != "community" ]]; then
         # We are the master and have just been notified of an appliance instance
 
-        dir=$(handler_dir)
-
-        if [[ "${appliance_roles}" == *":storage:"* ]]; then
-            appliance_url="https://storage.${cw_CLUSTER_name}.cloud.alces.network/"
-            # insert cluster name into URL in config file
-            sed -i "s%_APPLIANCE_URL_%${appliance_url}%" "${dir}"/var/alces-flight-www/alces-storage-manager/config.yml
-            "${cw_ROOT}"/libexec/share/www-add-resource "${dir}"/var/alces-flight-www/alces-storage-manager
+        if [[ "${appliance_roles}" == *":access:"* ]]; then
+          # We need to record the address of the Access appliance, so we can
+          # send it screenshots in the `session-screenshot` handler.
+          echo "cw_APPLIANCES_access_ADDRESS=${cw_MEMBER_ip}" >> \
+          "${cw_ROOT}/etc/config/cluster-appliances/cluster-appliances.rc"
         fi
 
-        if [[ "${appliance_roles}" == *":access:"* ]]; then
-            appliance_url="https://access.${cw_CLUSTER_name}.cloud.alces.network/"
-            # insert cluster name into URL in config file
-            sed -i "s%_APPLIANCE_URL_%${appliance_url}%" "${dir}"/var/alces-flight-www/alces-access-manager/config.yml
-            "${cw_ROOT}"/libexec/share/www-add-resource "${dir}"/var/alces-flight-www/alces-access-manager
+        if handler_is_enabled cluster-www; then
+          # Add appliance entry to cluster landing page.
+
+          dir=$(handler_dir)
+
+          if [[ "${appliance_roles}" == *":storage:"* ]]; then
+              appliance_url="https://storage.${cw_CLUSTER_name}.cloud.alces.network/"
+              # insert cluster name into URL in config file
+              sed -i "s%_APPLIANCE_URL_%${appliance_url}%" "${dir}"/var/alces-flight-www/alces-storage-manager/config.yml
+              "${cw_ROOT}"/libexec/share/www-add-resource "${dir}"/var/alces-flight-www/alces-storage-manager
+          fi
+
+          if [[ "${appliance_roles}" == *":access:"* ]]; then
+              appliance_url="https://access.${cw_CLUSTER_name}.cloud.alces.network/"
+              # insert cluster name into URL in config file
+              sed -i "s%_APPLIANCE_URL_%${appliance_url}%" "${dir}"/var/alces-flight-www/alces-access-manager/config.yml
+              "${cw_ROOT}"/libexec/share/www-add-resource "${dir}"/var/alces-flight-www/alces-access-manager
+          fi
         fi
     fi
 

--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -123,14 +123,14 @@ main() {
         dir=$(handler_dir)
 
         if [[ "${appliance_roles}" == *":storage:"* ]]; then
-            appliance_url = "https://storage.${cw_CLUSTER_name}.cloud.alces.network/"
+            appliance_url="https://storage.${cw_CLUSTER_name}.cloud.alces.network/"
             # insert cluster name into URL in config file
             sed -i "s/_APPLIANCE_URL_/${appliance_url}/" "${dir}"/var/alces-flight-www/alces-storage-manager/config.yml
             "${cw_ROOT}"/libexec/share/www-add-resource "${dir}"/var/alces-flight-www/alces-storage-manager
         fi
 
         if [[ "${appliance_roles}" == *":access:"* ]]; then
-            appliance_url = "https://access.${cw_CLUSTER_name}.cloud.alces.network/"
+            appliance_url="https://access.${cw_CLUSTER_name}.cloud.alces.network/"
             # insert cluster name into URL in config file
             sed -i "s/_APPLIANCE_URL_/${appliance_url}/" "${dir}"/var/alces-flight-www/alces-access-manager/config.yml
             "${cw_ROOT}"/libexec/share/www-add-resource "${dir}"/var/alces-flight-www/alces-access-manager

--- a/cluster-appliances/session-screenshot
+++ b/cluster-appliances/session-screenshot
@@ -28,7 +28,7 @@ main() {
 
         files_load_config --optional cluster-appliances config/cluster-appliances
         if [ "${cw_APPLIANCES_access_ADDRESS}" ]; then
-            cat <<JSON | webapi_post "${cw_APPLIANCES_access_ADDRESS}/api/v1/sessions/${sessionid}/screenshot"
+            cat <<JSON | webapi_post --location "${cw_APPLIANCES_access_ADDRESS}/api/v1/sessions/${sessionid}/screenshot"
 {
     "data": {
         "type": "screens",


### PR DESCRIPTION
These are a few changes to the cluster-appliances handler, needed for it to work better with the access appliance and master, as well as some fixes for writing the cluster landing page config for both types of appliance.
