### PR TITLE
Enable websocket proxy for access endpoints

### DIFF
--- a/cluster-appliances/configure
+++ b/cluster-appliances/configure
@@ -111,6 +111,7 @@ main() {
 
     if [[ "${cw_INSTANCE_tag_ACCESS_ROLES}" == *":master:"* ]]; then
         _fulfil_endpoint_role "access" "${cw_INSTANCE_tag_ACCESS_DAEMON_PORT:-25269}"
+        "${cw_ROOT}"/bin/alces service enable alces-flight-www/websocket-proxy
     fi
 
     if [[ "${cw_INSTANCE_role}" == "appliance" ]]; then


### PR DESCRIPTION
AAM client needs to connect to websockets within cluster via a proxy on
the login node, so this needs to be enabled to do this.
