### PR TITLE
Record AAM address for non-login nodes also

### DIFF
--- a/cluster-appliances/member-join
+++ b/cluster-appliances/member-join
@@ -117,15 +117,15 @@ main() {
         fi
     fi
 
+    if [[ "${appliance_roles}" == *":access:"* ]]; then
+      # We need to record the address of the Access appliance, so we can
+      # send it screenshots in the `session-screenshot` handler.
+      echo "cw_APPLIANCES_access_ADDRESS=${cw_MEMBER_ip}" >> \
+        "${cw_ROOT}/etc/config/cluster-appliances/cluster-appliances.rc"
+    fi
+
     if [[ "${cw_INSTANCE_role}" == "master" && "$(network_get_edition)" != "community" ]]; then
         # We are the master and have just been notified of an appliance instance
-
-        if [[ "${appliance_roles}" == *":access:"* ]]; then
-          # We need to record the address of the Access appliance, so we can
-          # send it screenshots in the `session-screenshot` handler.
-          echo "cw_APPLIANCES_access_ADDRESS=${cw_MEMBER_ip}" >> \
-          "${cw_ROOT}/etc/config/cluster-appliances/cluster-appliances.rc"
-        fi
 
         if handler_is_enabled cluster-www; then
           # Add appliance entry to cluster landing page.


### PR DESCRIPTION
VNC sessions can be started on compute nodes also, so we also need to
record the AAM address when the current node is not the login node, so
that session screenshots can be sent to it.
