### PR TITLE
Deny access to `alces customize pull` unless root

### DIFF
--- a/cluster-customizer/libexec/customize/actions/pull
+++ b/cluster-customizer/libexec/customize/actions/pull
@@ -23,8 +23,9 @@
 require action
 require handler
 require network
+require process
 
-action_die_unless_root
+process_reexec_sudo "$@"
 
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share

--- a/cluster-customizer/libexec/customize/actions/pull
+++ b/cluster-customizer/libexec/customize/actions/pull
@@ -24,6 +24,8 @@ require action
 require handler
 require network
 
+action_die_unless_root
+
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require customize


### PR DESCRIPTION
Along with the supporting Clusterware PR (https://github.com/alces-software/clusterware/pull/222), this is a fix for https://github.com/alces-software/clusterware/issues/206.
