### PR TITLE
Apply customization profiles at cluster runtime

### DIFF
--- a/cluster-customizer/libexec/actions/customize
+++ b/cluster-customizer/libexec/actions/customize
@@ -55,6 +55,7 @@ Customize your compute environment.
 
 Commands:
 EOF
+printf "    %-28s  %s\n" "$cw_BINNAME apply" "Download and install a customization profile."
 printf "    %-28s  %s\n" "$cw_BINNAME avail" "List available customization profiles."
 printf "    %-28s  %s\n" "$cw_BINNAME help" "More help about this command."
 printf "    %-28s  %s\n" "$cw_BINNAME list" "List installed customization profiles."

--- a/cluster-customizer/libexec/actions/customize
+++ b/cluster-customizer/libexec/actions/customize
@@ -42,8 +42,11 @@ case $action in
     p|pu|pul|pull)
         exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/pull "$@"
         ;;
-    a|av|ava|avai|avail)
+    av|ava|avai|avail)
         exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/avail "$@"
+        ;;
+    ap|app|appl|apply)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/apply "$@"
         ;;
     *)
         cat <<EOF

--- a/cluster-customizer/libexec/actions/customize
+++ b/cluster-customizer/libexec/actions/customize
@@ -55,6 +55,7 @@ Customize your compute environment.
 
 Commands:
 EOF
+printf "    %-28s  %s\n" "$cw_BINNAME avail" "List available customization profiles."
 printf "    %-28s  %s\n" "$cw_BINNAME help" "More help about this command."
 printf "    %-28s  %s\n" "$cw_BINNAME list" "List installed customization profiles."
 printf "    %-28s  %s\n" "$cw_BINNAME pull" "Pull updated customization actions from upstream."

--- a/cluster-customizer/libexec/actions/customize
+++ b/cluster-customizer/libexec/actions/customize
@@ -42,6 +42,9 @@ case $action in
     p|pu|pul|pull)
         exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/pull "$@"
         ;;
+    a|av|ava|avai|avail)
+        exec /bin/bash "${cw_ROOT}"/libexec/customize/actions/avail "$@"
+        ;;
     *)
         cat <<EOF
 Usage: $cw_BINNAME COMMAND [[OPTION]... [ARGS]]

--- a/cluster-customizer/libexec/customize/actions/apply
+++ b/cluster-customizer/libexec/customize/actions/apply
@@ -44,7 +44,7 @@ main() {
   if [[ "$nodes" ]]; then
     echo $nodes | tr ',' '\n' | while read node; do
       echo "Applying $1 to node $node..."
-      ssh $node 'alces handler enable cluster-customizer; alces customize apply "$1"' < /dev/null
+      ssh $node 'alces handler enable cluster-customizer; alces customize apply "'$1'"' < /dev/null
     done
   else
     if [[ "$type" == "feature" ]]; then

--- a/cluster-customizer/libexec/customize/actions/apply
+++ b/cluster-customizer/libexec/customize/actions/apply
@@ -27,7 +27,13 @@ require member
 require network
 
 main() {
-  local type profile_name
+  local type profile_name nodes
+
+  if [ "$1" == "-n" ]; then
+      nodes="$2"
+      shift 2
+  fi
+
   type=${1%%/*}
   profile_name=${1##*/}
   if [[ "$type" == "$profile_name" ]]; then
@@ -35,12 +41,19 @@ main() {
     return 1
   fi
 
-  if [[ "$type" == "feature" ]]; then
-    customize_apply_feature "$profile_name"
-  elif [[ "$type" == "profile" ]]; then
-    customize_apply_profile "$profile_name"
+  if [[ "$nodes" ]]; then
+    echo $nodes | tr ',' '\n' | while read node; do
+      echo "Applying $1 to node $node..."
+      ssh $node alces customize apply "$1" < /dev/null
+    done
   else
-    echo "Unknown customization type: $type"
+    if [[ "$type" == "feature" ]]; then
+      customize_apply_feature "$profile_name"
+    elif [[ "$type" == "profile" ]]; then
+      customize_apply_profile "$profile_name"
+    else
+      echo "Unknown customization type: $type"
+    fi
   fi
 }
 

--- a/cluster-customizer/libexec/customize/actions/apply
+++ b/cluster-customizer/libexec/customize/actions/apply
@@ -1,0 +1,53 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+require process
+require network
+
+main() {
+  local type profile_name
+  type=${1##/}
+  profile_name=${1%%/}
+  echo "Type: $type"
+  echo "Profile: $profile_name"
+}
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require customize
+
+    if network_has_metadata_service 1; then
+        files_load_config cluster-customizer
+        cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
+        cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
+
+        process_reexec_sudo "$@"
+
+        main "$@"
+    else
+        action_die 'unable to apply: no cloud metadata service detected'
+    fi
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/cluster-customizer/libexec/customize/actions/apply
+++ b/cluster-customizer/libexec/customize/actions/apply
@@ -44,7 +44,7 @@ main() {
   if [[ "$nodes" ]]; then
     echo $nodes | tr ',' '\n' | while read node; do
       echo "Applying $1 to node $node..."
-      ssh $node alces customize apply "$1" < /dev/null
+      ssh $node 'alces handler enable cluster-customizer; alces customize apply "$1"' < /dev/null
     done
   else
     if [[ "$type" == "feature" ]]; then

--- a/cluster-customizer/libexec/customize/actions/apply
+++ b/cluster-customizer/libexec/customize/actions/apply
@@ -35,9 +35,9 @@ main() {
   fi
 
   if [[ "$type" == "feature" ]]; then
-    echo "Requested feature $profile_name"
+    customize_apply_feature "$profile_name"
   elif [[ "$type" == "profile" ]]; then
-    echo "Requested profile $profile_name"
+    customize_apply_profile "$profile_name"
   else
     echo "Unknown customization type: $type"
   fi

--- a/cluster-customizer/libexec/customize/actions/apply
+++ b/cluster-customizer/libexec/customize/actions/apply
@@ -27,8 +27,8 @@ require network
 
 main() {
   local type profile_name
-  type=${1##/}
-  profile_name=${1%%/}
+  type=${1%%/*}
+  profile_name=${1##*/}
   echo "Type: $type"
   echo "Profile: $profile_name"
 }

--- a/cluster-customizer/libexec/customize/actions/apply
+++ b/cluster-customizer/libexec/customize/actions/apply
@@ -44,7 +44,7 @@ main() {
   if [[ "$nodes" ]]; then
     echo $nodes | tr ',' '\n' | while read node; do
       echo "Applying $1 to node $node..."
-      ssh $node 'alces handler enable cluster-customizer; alces customize apply "'$1'"' < /dev/null
+      ssh $node 'alces handler enable cluster-customizer; alces service install s3cmd; alces customize apply "'$1'"' < /dev/null
     done
   else
     if [[ "$type" == "feature" ]]; then

--- a/cluster-customizer/libexec/customize/actions/apply
+++ b/cluster-customizer/libexec/customize/actions/apply
@@ -29,8 +29,18 @@ main() {
   local type profile_name
   type=${1%%/*}
   profile_name=${1##*/}
-  echo "Type: $type"
-  echo "Profile: $profile_name"
+  if [[ "$type" == "$profile_name" ]]; then
+    echo "Incorrect format for customization profile: $type"
+    return 1
+  fi
+
+  if [[ "$type" == "feature" ]]; then
+    echo "Requested feature $profile_name"
+  elif [[ "$type" == "profile" ]]; then
+    echo "Requested profile $profile_name"
+  else
+    echo "Unknown customization type: $type"
+  fi
 }
 
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then

--- a/cluster-customizer/libexec/customize/actions/apply
+++ b/cluster-customizer/libexec/customize/actions/apply
@@ -23,6 +23,7 @@
 require action
 require handler
 require process
+require member
 require network
 
 main() {

--- a/cluster-customizer/libexec/customize/actions/avail
+++ b/cluster-customizer/libexec/customize/actions/avail
@@ -27,7 +27,14 @@ if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require customize
 
-    echo "avail command not yet written! Coming soon™"
+    if network_has_metadata_service 1; then
+        files_load_config cluster-customizer
+        cw_CLUSTER_CUSTOMIZER_path="${cw_CLUSTER_CUSTOMIZER_path:-${cw_ROOT}/var/lib/customizer}"
+        cw_CLUSTER_CUSTOMIZER_profiles="${cw_CLUSTER_CUSTOMIZER_profiles:-default}"
+        customize_list
+    else
+        action_die 'unable to pull: no cloud metadata service detected'
+    fi
 else
     action_die 'cluster-customizer handler is not enabled'
 fi

--- a/cluster-customizer/libexec/customize/actions/avail
+++ b/cluster-customizer/libexec/customize/actions/avail
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require network
 
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share

--- a/cluster-customizer/libexec/customize/actions/avail
+++ b/cluster-customizer/libexec/customize/actions/avail
@@ -27,7 +27,7 @@ if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require customize
 
-    echo "avail command not yet written! Coming soon™"
+    echo "avail command not yet written! Coming soon™..."
 else
     action_die 'cluster-customizer handler is not enabled'
 fi

--- a/cluster-customizer/libexec/customize/actions/avail
+++ b/cluster-customizer/libexec/customize/actions/avail
@@ -27,7 +27,7 @@ if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require customize
 
-    echo "avail command not yet written! Coming soon™..."
+    echo "avail command not yet written! Coming soon™"
 else
     action_die 'cluster-customizer handler is not enabled'
 fi

--- a/cluster-customizer/libexec/customize/actions/avail
+++ b/cluster-customizer/libexec/customize/actions/avail
@@ -1,0 +1,33 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require action
+require handler
+
+if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
+    require customize
+
+    echo "avail command not yet written! Coming soon™"
+else
+    action_die 'cluster-customizer handler is not enabled'
+fi

--- a/cluster-customizer/libexec/customize/actions/help
+++ b/cluster-customizer/libexec/customize/actions/help
@@ -27,7 +27,7 @@ main() {
     shift
 
     case $action in
-        help|list|trigger|pull)
+        avail|help|list|trigger|pull)
             help_for_${action}
             ;;
         ?*)
@@ -39,6 +39,19 @@ main() {
             general_help
             ;;
     esac
+}
+
+help_for_avail() {
+  cat <<EOF
+SYNOPSIS:
+
+  alces customize avail
+
+DESCRIPTION:
+
+  List customization profiles that are available but not installed.
+
+EOF
 }
 
 help_for_help() {
@@ -121,6 +134,7 @@ general_help() {
   COMMANDS:
 
 EOF
+printf "    %-28s  %s\n" "$cw_BINNAME avail" "List available customization profiles."
 printf "    %-28s  %s\n" "$cw_BINNAME help" "More help about this command."
 printf "    %-28s  %s\n" "$cw_BINNAME list" "List installed customization profiles."
 printf "    %-28s  %s\n" "$cw_BINNAME pull" "Pull updated customization actions from upstream."

--- a/cluster-customizer/libexec/customize/actions/help
+++ b/cluster-customizer/libexec/customize/actions/help
@@ -27,7 +27,7 @@ main() {
     shift
 
     case $action in
-        avail|help|list|trigger|pull)
+        apply|avail|help|list|trigger|pull)
             help_for_${action}
             ;;
         ?*)
@@ -39,6 +39,35 @@ main() {
             general_help
             ;;
     esac
+}
+
+help_for_apply() {
+    cat <<EOF
+  SYNOPSIS:
+
+    alces customize apply [OPTIONS] <profile>
+
+  DESCRIPTION:
+
+    Download and install a customization <profile> to the current
+    node or, optionally, a list of other nodes in the cluster.
+
+    A list of available customization profiles can be shown by
+    running "alces customize avail".
+
+    Once downloaded, the customization will have its initialize and
+    configure events triggered, along with a member-join event for
+    each current member of the cluster.
+
+  OPTIONS:
+
+    -n <node list>
+      You may specify a comma-separated list of nodes on which the
+      customization profile should be installed. When this option is
+      specified the customization will not be applied to the current
+      node, unless it appears in the <node list>.
+
+EOF
 }
 
 help_for_avail() {
@@ -134,6 +163,7 @@ general_help() {
   COMMANDS:
 
 EOF
+printf "    %-28s  %s\n" "$cw_BINNAME apply" "Download and install a customization profile."
 printf "    %-28s  %s\n" "$cw_BINNAME avail" "List available customization profiles."
 printf "    %-28s  %s\n" "$cw_BINNAME help" "More help about this command."
 printf "    %-28s  %s\n" "$cw_BINNAME list" "List installed customization profiles."

--- a/cluster-customizer/libexec/customize/actions/help
+++ b/cluster-customizer/libexec/customize/actions/help
@@ -55,9 +55,9 @@ help_for_apply() {
     A list of available customization profiles can be shown by
     running "alces customize avail".
 
-    Once downloaded, the customization will have its initialize and
-    configure events triggered, along with a member-join event for
-    each current member of the cluster.
+    Once downloaded, the customization will have its configure event
+    triggered, along with a member-join event for each current member
+    of the cluster.
 
   OPTIONS:
 

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -190,7 +190,6 @@ customize_is_s3_access_available() {
 }
 
 customize_set_s3_config() {
-  local s3cfg
   customize_set_region
   s3cfg="$(mktemp /tmp/cluster-customizer.s3cfg.XXXXXXXX)"
   cat <<EOF > "${s3cfg}"
@@ -205,6 +204,7 @@ EOF
 
 customize_clear_s3_config() {
   rm -f "${s3cfg}"
+  unset s3cfg
 }
 
 customize_fetch() {

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -311,3 +311,15 @@ customize_list() {
   customize_list_features "${s3cfg}"
   customize_clear_s3_config
 }
+
+customize_apply_profile() {
+  local profile_name
+  profile_name="$1"
+  echo "Requested apply profile $profile_name"
+}
+
+customize_apply_feature() {
+  local feature_name
+  feature_name="$1"
+  echo "Requested apply feature $feature_name"
+}

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -388,10 +388,9 @@ customize_apply() {
       member_each _run_member_hooks "${members}" "member-join:$type-$name"
       return 0
     fi
-  else
-    echo "Applying profile failed."
-    return 1
   fi
+  echo "Applying profile failed."
+  return 1
 }
 
 customize_apply_profile() {

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -410,7 +410,7 @@ customize_apply_profile() {
       bucket="${cw_CLUSTER_CUSTOMIZER_bucket#s3://}"
   fi
 
-  echo "Requested apply profile $profile_name"
+  echo "Applying profile $profile_name..."
 
   customize_apply "$bucket" "$profile_name" "profile"
 
@@ -425,7 +425,7 @@ customize_apply_feature() {
 
   bucket="alces-flight-profiles-${_REGION}"
 
-  echo "Requested apply feature $feature_name"
+  echo "Applying feature $feature_name..."
 
   customize_apply "$bucket" "$feature_name" "feature"
 

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -374,9 +374,9 @@ customize_apply_profile() {
     sed -i "s/cw_CLUSTER_CUSTOMIZER_profiles=.*/cw_CLUSTER_CUSTOMIZER_profiles=\"$cw_CLUSTER_CUSTOMIZER_profiles $profile_name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
     chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}"/profile-${profile_name}
     echo "Running initialize, configure for $profile_name"
-    customize_run_hooks "initialize:$profile_name"
-    customize_run_hooks "configure:$profile_name"
-    member_each _run_member_hooks "${members}" "member-join:$profile_name"
+    customize_run_hooks "initialize:profile-$profile_name"
+    customize_run_hooks "configure:profile-$profile_name"
+    member_each _run_member_hooks "${members}" "member-join:profile-$profile_name"
   else
     echo "Applying profile failed."
     return 1
@@ -408,9 +408,9 @@ customize_apply_feature() {
     sed -i "s/cw_CLUSTER_CUSTOMIZER_features=.*/cw_CLUSTER_CUSTOMIZER_features=\"$cw_CLUSTER_CUSTOMIZER_features $feature_name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
     chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}"/feature-${feature_name}
     echo "Running initialize, configure for $feature_name"
-    customize_run_hooks "initialize:$feature_name"
-    customize_run_hooks "configure:$feature_name"
-    member_each _run_member_hooks "${members}" "member-join:$feature_name"
+    customize_run_hooks "initialize:feature-$feature_name"
+    customize_run_hooks "configure:feature-$feature_name"
+    member_each _run_member_hooks "${members}" "member-join:feature-$feature_name"
   else
     echo "Applying profile failed."
     return 1

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -219,3 +219,28 @@ customize_fetch() {
     chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}"
     customize_clear_s3_config
 }
+
+customize_list_features() {
+  local bucket profile
+  if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
+      if network_is_ec2; then
+          bucket="alces-flight-$(network_ec2_hashed_account)"
+      else
+          echo "Unable to determine bucket name for customizations"
+          return 0
+      fi
+  else
+      bucket="${cw_CLUSTER_CUSTOMIZER_bucket#s3://}"
+  fi
+  if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
+      echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
+      s3cfg=""
+  fi
+  "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}" | grep manifest.txt | awk '{ print $4 }'
+}
+
+customize_list() {
+  customize_set_s3_config
+  customize_list_features "${s3cfg}"
+  customize_clear_s3_config
+}

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -189,11 +189,11 @@ customize_is_s3_access_available() {
     "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} ls "s3://${bucket}" 2>/dev/null
 }
 
-customize_fetch() {
-    local s3cfg
-    customize_set_region
-    s3cfg="$(mktemp /tmp/cluster-customizer.s3cfg.XXXXXXXX)"
-    cat <<EOF > "${s3cfg}"
+customize_set_s3_config() {
+  local s3cfg
+  customize_set_region
+  s3cfg="$(mktemp /tmp/cluster-customizer.s3cfg.XXXXXXXX)"
+  cat <<EOF > "${s3cfg}"
 [default]
 access_key = "${cw_CLUSTER_CUSTOMIZER_access_key_id}"
 secret_key = "${cw_CLUSTER_CUSTOMIZER_secret_access_key}"
@@ -201,6 +201,14 @@ security_token = ""
 use_https = True
 check_ssl_certificate = True
 EOF
+}
+
+customize_clear_s3_config() {
+  rm -f "${s3cfg}"
+}
+
+customize_fetch() {
+    customize_set_s3_config
     mkdir -p "${cw_CLUSTER_CUSTOMIZER_path}"
     customize_set_machine_type
     if [ "${_MACHINE_TYPE}" ]; then
@@ -209,5 +217,5 @@ EOF
     customize_fetch_features "${s3cfg}"
     customize_fetch_profiles "${s3cfg}"
     chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}"
-    rm -f "${s3cfg}"
+    customize_clear_s3_config
 }

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -220,6 +220,14 @@ customize_fetch() {
     customize_clear_s3_config
 }
 
+customize_list_from_s3() {
+  local s3cfg url
+  s3cfg=$1
+  url=$2
+  # Arg $4 is the manifest file path; split on /; the second-last element is the profile name
+  "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "${url}" | grep manifest.txt | awk '{ b=split($4, a, "/"); print a[b-1] }'
+}
+
 customize_list_profiles() {
   local bucket
   if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
@@ -237,8 +245,7 @@ customize_list_profiles() {
       s3cfg=""
   else
     echo "Account profiles available:"
-    # Arg $4 is the manifest file path; split on /; the second-last element is the profile name
-    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}/customizer" | grep manifest.txt | awk '{ b=split($4, a, "/"); print a[b-1] }'
+    customize_list_from_s3 "$s3cfg" "s3://${bucket}/customizer"
   fi
 }
 
@@ -251,8 +258,7 @@ customize_list_features() {
       s3cfg=""
   else
     echo "Feature profiles available:"
-    # Arg $4 is the manifest file path; split on /; the second-last element is the profile name
-    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}/features" | grep manifest.txt | awk '{ b=split($4, a, "/"); print a[b-1] }'
+    customize_list_from_s3 "$s3cfg" "s3://${bucket}/features"
   fi
 }
 

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -372,6 +372,7 @@ customize_apply_profile() {
 
   if [[ $? -eq 0 ]]; then
     sed -i "s/cw_CLUSTER_CUSTOMIZER_profiles=.*/cw_CLUSTER_CUSTOMIZER_profiles=\"$cw_CLUSTER_CUSTOMIZER_profiles $profile_name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
+    chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}"/profile-${profile_name}
     echo "Running initialize, configure for $profile_name"
     customize_run_hooks "initialize:$profile_name"
     customize_run_hooks "configure:$profile_name"
@@ -405,6 +406,7 @@ customize_apply_feature() {
 
   if [[ $? -eq 0 ]]; then
     sed -i "s/cw_CLUSTER_CUSTOMIZER_features=.*/cw_CLUSTER_CUSTOMIZER_features=\"$cw_CLUSTER_CUSTOMIZER_features $feature_name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
+    chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}"/feature-${feature_name}
     echo "Running initialize, configure for $feature_name"
     customize_run_hooks "initialize:$feature_name"
     customize_run_hooks "configure:$feature_name"

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -340,7 +340,7 @@ customize_apply_profile() {
   customize_fetch_profile "${s3cfg}" "${bucket}"/customizer/"${profile_name}" \
                           "${cw_CLUSTER_CUSTOMIZER_path}"/profile-${profile_name}
 
-  sed -i "s/cw_CLUSTER_CUSTOMIZER_profiles=.*/cw_CLUSTER_CUSTOMIZER_profiles=\"$cw_CLUSTER_CUSTOMIZER_profiles $profile_name\"" "$cw_ROOT"/etc/cluster_customizer.rc
+  sed -i "s/cw_CLUSTER_CUSTOMIZER_profiles=.*/cw_CLUSTER_CUSTOMIZER_profiles=\"$cw_CLUSTER_CUSTOMIZER_profiles $profile_name\"/" "$cw_ROOT"/etc/cluster_customizer.rc
 
   customize_clear_s3_config
 }

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -104,7 +104,7 @@ customize_fetch_profile() {
     target="$3"
     mkdir -p "${target}"
     if [ "${s3cfg}" ]; then
-        "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} mb "s3://${source%/*}" &>/dev/null
+        "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} mb "s3://${source%%/*}" &>/dev/null
         "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --force -r get "s3://${source}"/ "${target}"
     else
         # fetch manifest file

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -346,7 +346,17 @@ customize_profile_can_be_installed() {
   local initCount s3cfg source
   s3cfg="$1"
   source="$2"
-  initCount=$("${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} ls "s3://${source}"/initialize.d 2>/dev/null | wc -l)
+  if [ "$s3cfg" ]; then
+    initCount=$("${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} ls "s3://${source}"/initialize.d 2>/dev/null | wc -l)
+  else
+    if [ "${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}" == "us-east-1" ]; then
+        host=s3.amazonaws.com
+    else
+        host=s3-${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}.amazonaws.com
+    fi
+    initCount=$(curl -s -f https://${host}/${source}/manifest.txt | grep "initialize.d" | wc -l)
+  fi
+
   if [[ $initCount == 0 ]]; then
     return 0
   else

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -232,9 +232,9 @@ customize_print_list_excluding() {
   local ex existing av avail found
   avail="$1"
   existing="$2"
-  for av in "$avail"; do
+  for av in $avail; do
     found=false
-    for ex in "$existing"; do
+    for ex in $existing; do
       if [[ "$av" == "$existing" ]]; then
         found=true
         break

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -374,6 +374,7 @@ customize_apply_profile() {
     sed -i "s/cw_CLUSTER_CUSTOMIZER_profiles=.*/cw_CLUSTER_CUSTOMIZER_profiles=\"$cw_CLUSTER_CUSTOMIZER_profiles $profile_name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
     echo "Running initialize, configure for $profile_name"
     customize_run_hooks "initialize:$profile_name"
+    customize_run_hooks "configure:$profile_name"
     member_each _run_member_hooks "${members}" "member-join:$profile_name"
   else
     echo "Applying profile failed."
@@ -406,6 +407,7 @@ customize_apply_feature() {
     sed -i "s/cw_CLUSTER_CUSTOMIZER_features=.*/cw_CLUSTER_CUSTOMIZER_features=\"$cw_CLUSTER_CUSTOMIZER_features $feature_name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
     echo "Running initialize, configure for $feature_name"
     customize_run_hooks "initialize:$feature_name"
+    customize_run_hooks "configure:$feature_name"
     member_each _run_member_hooks "${members}" "member-join:$feature_name"
   else
     echo "Applying profile failed."

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -247,9 +247,10 @@ customize_list_from_http() {
 }
 
 customize_print_list_excluding() {
-  local ex existing av avail found
+  local ex existing av avail found prefix
   avail="$1"
   existing="$2"
+  prefix="$3"
   for av in $avail; do
     found=false
     for ex in $existing; do
@@ -259,7 +260,7 @@ customize_print_list_excluding() {
       fi
     done
     if [[ "$found" == false ]]; then
-      echo " - $av"
+      echo " - $prefix/$av"
     fi
   done
 }
@@ -284,8 +285,7 @@ customize_list_profiles() {
   else
     avail=$(customize_list_from_s3 "$s3cfg" "s3://${bucket}/customizer")
   fi
-  echo "Account profiles available:"
-  customize_print_list_excluding "$avail" "$existing"
+  customize_print_list_excluding "$avail" "$existing" "profile"
 }
 
 customize_list_features() {
@@ -302,8 +302,7 @@ customize_list_features() {
   else
     avail=$(customize_list_from_s3 "$s3cfg" "s3://${bucket}/features")
   fi
-  echo "Feature profiles available:"
-  customize_print_list_excluding "$avail" "$existing"
+  customize_print_list_excluding "$avail" "$existing" "feature"
 }
 
 customize_list() {

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -229,7 +229,7 @@ customize_list_from_s3() {
 }
 
 customize_list_profiles() {
-  local bucket
+  local bucket ex existing av avail found
   if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
       if network_is_ec2; then
           bucket="alces-flight-$(network_ec2_hashed_account)"
@@ -240,12 +240,26 @@ customize_list_profiles() {
   else
       bucket="${cw_CLUSTER_CUSTOMIZER_bucket#s3://}"
   fi
+  existing="$(mktemp /tmp/cluster-customizer.s3cfg.XXXXXXXX)"
+  ls "${cw_CLUSTER_CUSTOMIZER_path}" | grep -Po "(?<=profile-).*"grep -Po "(?<=profile-).*" > existing
   if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
       echo "S3 access to '${bucket}' is not available.  HTTP not yet implemented. Sorry."
       s3cfg=""
   else
     echo "Account profiles available:"
-    customize_list_from_s3 "$s3cfg" "s3://${bucket}/customizer"
+    avail=$(customize_list_from_s3 "$s3cfg" "s3://${bucket}/customizer")
+    for av in avail; do
+      found=false
+      for ex in existing; do
+        if [[ "$av" == "$existing" ]]; then
+          found=true
+          break
+        fi
+      done
+      if [[ !"$found" ]]; then
+        echo av
+      fi
+    done
   fi
 }
 

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -254,7 +254,7 @@ customize_print_list_excluding() {
   for av in $avail; do
     found=false
     for ex in $existing; do
-      if [[ "$av" == "$existing" ]]; then
+      if [[ "$av" == "$ex" ]]; then
         found=true
         break
       fi

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -233,10 +233,11 @@ customize_list_features() {
       bucket="${cw_CLUSTER_CUSTOMIZER_bucket#s3://}"
   fi
   if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
-      echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
+      echo "S3 access to '${bucket}' is not available.  HTTP not yet implemented. Sorry."
       s3cfg=""
+  else
+    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}" | grep manifest.txt | awk '{ print $4 }'
   fi
-  "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}" | grep manifest.txt | awk '{ print $4 }'
 }
 
 customize_list() {

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -372,8 +372,9 @@ customize_apply_profile() {
 
   if [[ $? -eq 0 ]]; then
     sed -i "s/cw_CLUSTER_CUSTOMIZER_profiles=.*/cw_CLUSTER_CUSTOMIZER_profiles=\"$cw_CLUSTER_CUSTOMIZER_profiles $profile_name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
-    customize_run_hooks "$profile_name:initialize"
-    member_each _run_member_hooks "${members}" "$profile_name:member-join"
+    echo "Running initialize, configure for $profile_name"
+    customize_run_hooks "initialize:$profile_name"
+    member_each _run_member_hooks "${members}" "member-join:$profile_name"
   else
     echo "Applying profile failed."
     return 1
@@ -403,8 +404,9 @@ customize_apply_feature() {
 
   if [[ $? -eq 0 ]]; then
     sed -i "s/cw_CLUSTER_CUSTOMIZER_features=.*/cw_CLUSTER_CUSTOMIZER_features=\"$cw_CLUSTER_CUSTOMIZER_features $feature_name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
-    customize_run_hooks "$feature_name:initialize"
-    member_each _run_member_hooks "${members}" "$feature_name:member-join"
+    echo "Running initialize, configure for $feature_name"
+    customize_run_hooks "initialize:$feature_name"
+    member_each _run_member_hooks "${members}" "member-join:$feature_name"
   else
     echo "Applying profile failed."
     return 1

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -237,7 +237,8 @@ customize_list_profiles() {
       s3cfg=""
   else
     echo "Account profiles available:"
-    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}/customizer" | grep manifest.txt | awk '{ print $4 }'
+    # Arg $4 is the manifest file path; split on /; the second-last element is the profile name
+    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}/customizer" | grep manifest.txt | awk '{ b=split($4, a, "/"); print a[b-1] }'
   fi
 }
 
@@ -250,7 +251,8 @@ customize_list_features() {
       s3cfg=""
   else
     echo "Feature profiles available:"
-    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}/features" | grep manifest.txt | awk '{ print $4 }'
+    # Arg $4 is the manifest file path; split on /; the second-last element is the profile name
+    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}/features" | grep manifest.txt | awk '{ b=split($4, a, "/"); print a[b-1] }'
   fi
 }
 

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -236,12 +236,27 @@ customize_list_profiles() {
       echo "S3 access to '${bucket}' is not available.  HTTP not yet implemented. Sorry."
       s3cfg=""
   else
+    echo "Account profiles available:"
     "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}/customizer" | grep manifest.txt | awk '{ print $4 }'
+  fi
+}
+
+customize_list_features() {
+  local bucket feature s3cfg
+  s3cfg=$1
+  bucket="alces-flight-profiles-${_REGION}"
+  if ! customize_is_s3_access_available "${s3cfg}" "${bucket}"; then
+      echo "S3 access to '${bucket}' is not available.  Falling back to HTTP manifests."
+      s3cfg=""
+  else
+    echo "Feature profiles available:"
+    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}/features" | grep manifest.txt | awk '{ print $4 }'
   fi
 }
 
 customize_list() {
   customize_set_s3_config
   customize_list_profiles "${s3cfg}"
+  customize_list_features "${s3cfg}"
   customize_clear_s3_config
 }

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -220,8 +220,8 @@ customize_fetch() {
     customize_clear_s3_config
 }
 
-customize_list_features() {
-  local bucket profile
+customize_list_profiles() {
+  local bucket
   if [ -z "${cw_CLUSTER_CUSTOMIZER_bucket}" ]; then
       if network_is_ec2; then
           bucket="alces-flight-$(network_ec2_hashed_account)"
@@ -236,12 +236,12 @@ customize_list_features() {
       echo "S3 access to '${bucket}' is not available.  HTTP not yet implemented. Sorry."
       s3cfg=""
   else
-    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}" | grep manifest.txt | awk '{ print $4 }'
+    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} --recursive ls "s3://${bucket}/customizer" | grep manifest.txt | awk '{ print $4 }'
   fi
 }
 
 customize_list() {
   customize_set_s3_config
-  customize_list_features "${s3cfg}"
+  customize_list_profiles "${s3cfg}"
   customize_clear_s3_config
 }

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -240,8 +240,8 @@ customize_print_list_excluding() {
         break
       fi
     done
-    if [[ !"$found" ]]; then
-      echo "$av"
+    if [[ "$found" == false ]]; then
+      echo " - $av"
     fi
   done
 }

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -383,8 +383,7 @@ customize_apply() {
     if [[ $? -eq 0 ]]; then
       sed -i "s/$varname=.*/$varname=\"${!varname} $name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
       chmod -R a+x "${cw_CLUSTER_CUSTOMIZER_path}/${type}-${name}"
-      echo "Running initialize, configure for $name"
-      customize_run_hooks "initialize:$type-$name"
+      echo "Running configure for $name"
       customize_run_hooks "configure:$type-$name"
       member_each _run_member_hooks "${members}" "member-join:$type-$name"
       return 0

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -186,7 +186,7 @@ customize_is_s3_access_available() {
     local s3cfg bucket
     s3cfg="$1"
     bucket="$2"
-    "${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} ls "s3://${bucket}" 2>/dev/null
+    "${cw_ROOT}"/opt/s3cmd/s3cmd -q -c ${s3cfg} ls "s3://${bucket}" 2>/dev/null
 }
 
 customize_set_s3_config() {

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -122,10 +122,12 @@ customize_fetch_profile() {
                     echo "Fetched: ${source}/${f}"
                 else
                     echo "Unable to fetch: ${source}/${f}"
+                    return 1
                 fi
             done
         else
             echo "No manifest found for: ${source}"
+            return 1
         fi
     fi
 }
@@ -340,7 +342,12 @@ customize_apply_profile() {
   customize_fetch_profile "${s3cfg}" "${bucket}"/customizer/"${profile_name}" \
                           "${cw_CLUSTER_CUSTOMIZER_path}"/profile-${profile_name}
 
-  sed -i "s/cw_CLUSTER_CUSTOMIZER_profiles=.*/cw_CLUSTER_CUSTOMIZER_profiles=\"$cw_CLUSTER_CUSTOMIZER_profiles $profile_name\"/" "$cw_ROOT"/etc/cluster_customizer.rc
+  if [[ $? -eq 0 ]]; then
+    sed -i "s/cw_CLUSTER_CUSTOMIZER_profiles=.*/cw_CLUSTER_CUSTOMIZER_profiles=\"$cw_CLUSTER_CUSTOMIZER_profiles $profile_name\"/" "$cw_ROOT"/etc/cluster-customizer.rc
+  else
+    echo "Applying profile failed."
+    return 1
+  fi
 
   customize_clear_s3_config
 }

--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -368,9 +368,10 @@ customize_apply_profile() {
 customize_apply_feature() {
   local bucket feature_name
   feature_name="$1"
-  bucket="alces-flight-profiles-${_REGION}"
 
   customize_set_s3_config
+
+  bucket="alces-flight-profiles-${_REGION}"
 
   echo "Requested apply feature $feature_name"
 


### PR DESCRIPTION
This PR allows cluster administrators to download and install customization profiles (both user-managed account profiles and Alces-managed feature profiles, though not 'machine' profiles) while a cluster is running.

The new `alces customize avail` command will list account and feature profiles that are in their respective S3 repositories but not yet installed. `alces customize apply` will download a profile, run its `configure` trigger, and its `member-join` trigger for all current cluster members.

Specifying a comma-separated list of cluster nodes e.g. `alces customize apply -n node01,node04 profile/someProfile` will download and apply the `someProfile` account profile only on nodes `node01` and `node04`. It is assumed that the S3 configuration on all nodes will be the same (or at least grant access to the same set of profiles).

Profiles containing `initialize` scripts are likely to not function correctly when installed post-cluster-initialization, so we do not support installing them through this method. We check for the presence of any `initialize.d` scripts and fail before installing if any are present.