### PR TITLE
Improve prohibition of non-applyable profiles

### DIFF
--- a/cluster-customizer/share/customize.functions.sh
+++ b/cluster-customizer/share/customize.functions.sh
@@ -334,18 +334,21 @@ _run_member_hooks() {
 }
 
 customize_profile_can_be_installed() {
-  local initCount s3cfg source
+  local expression initCount s3cfg source
   s3cfg="$1"
   source="$2"
+
+  expression="(initialize|preconfigure)\.d"
+
   if [ "$s3cfg" ]; then
-    initCount=$("${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} ls "s3://${source}"/initialize.d 2>/dev/null | wc -l)
+    initCount=$("${cw_ROOT}"/opt/s3cmd/s3cmd -c ${s3cfg} ls "s3://${source}"/ | grep -E "$expression" | wc -l)
   else
     if [ "${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}" == "us-east-1" ]; then
         host=s3.amazonaws.com
     else
         host=s3-${_REGION:-${cw_CLUSTER_CUSTOMIZER_region:-eu-west-1}}.amazonaws.com
     fi
-    initCount=$(curl -s -f https://${host}/${source}/manifest.txt | grep "initialize.d" | wc -l)
+    initCount=$(curl -s -f https://${host}/${source}/manifest.txt | grep -E "$expression" | wc -l)
   fi
 
   if [[ $initCount == 0 ]]; then


### PR DESCRIPTION
This PR makes two changes to the `alces customize` command relating to non-`apply`able customization profiles:

- Profiles containing a `preconfigure.d` directory are non-`apply`able, in addition to those with an `initialize.d` directory. Trying to `alces customize apply` them will return an error.
- Non-`apply`able profiles are no longer shown in the list of available profiles from `alces customize avail`.