### PR TITLE
Support multiple autoscaling groups in Slurm

### DIFF
--- a/autoscaling/share/providers/aws
+++ b/autoscaling/share/providers/aws
@@ -130,7 +130,7 @@ aws_shoot_node() {
 
 aws_scale_out() {
   local cores_per_node groups g tmpfile
-  local byslot_nodes_req_var bynode_nodes_req_var nodes_req
+  local nodes_req_var nodes_req
   local current current_max current_desired
 
   groups="$(_list_autoscaling_groups)"
@@ -146,9 +146,8 @@ aws_scale_out() {
       # cat "${tmpfile}" | _log_blob "metrics" # This makes logs very noisy but is useful for development/debugging
       . "${tmpfile}"
 
-      bynode_nodes_req_var="${scheduler}_queue_${gg}_bynode_q_nodes_req"
-      byslot_nodes_req_var="${scheduler}_queue_${gg}_byslot_q_nodes_req"
-      nodes_req=$((${nodes_req:-0}+${!byslot_nodes_req_var:-0}+${!bynode_nodes_req_var:-0}))
+      nodes_req_var="${scheduler}_queue_${gg}_nodes_req"
+      nodes_req=$((${nodes_req:-0}+${!nodes_req_var:-0}))
     done
     log "[autoscaler:aws-scale-out] Autoscaling group $g has demand for $nodes_req nodes"
 

--- a/cluster-slurm/autoscaling-member-join
+++ b/cluster-slurm/autoscaling-member-join
@@ -45,6 +45,7 @@ main() {
     handler_add_libdir share
     require slurm-handler
 
+    files_load_config instance config/cluster
     files_load_config --optional cluster-slurm
     export cw_CLUSTER_SLURM_config="${cw_CLUSTER_SLURM_config:-"${cw_ROOT}"/opt/slurm/etc/slurm.conf}"
     handler_tee main "$@"

--- a/cluster-slurm/autoscaling-member-join
+++ b/cluster-slurm/autoscaling-member-join
@@ -1,0 +1,50 @@
+#!/bin/bash
+################################################################################
+##
+## Alces Clusterware - Handler hook
+## Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+##
+################################################################################
+setup() {
+    local a xdg_config
+    IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+    for a in "${xdg_config[@]}"; do
+        if [ -e "${a}"/clusterware/config.rc ]; then
+            source "${a}"/clusterware/config.rc
+            break
+        fi
+    done
+    if [ -z "${cw_ROOT}" ]; then
+        echo "$0: unable to locate clusterware configuration"
+        exit 1
+    fi
+    kernel_load
+}
+
+main() {
+  local hostname ip groupname group_max_size cores_per_node
+  echo "Received autoscaling-member-join with args ${*}"
+
+  if [[ "${cw_INSTANCE_tag_SCHEDULER_ROLES}" == *":master:"* ]]; then
+    hostname="$1"
+    ip="$2"
+    groupname="$3"
+    group_max_size="$4"
+    cores_per_node="$5"
+
+    handler_run_helper share/add-partition-if-not-exist "$groupname" "$group_max_size"
+    handler_run_helper share/add-node-to-partition "$hostname" "$groupname"
+
+  fi
+}
+
+    setup
+    require handler
+    require files
+
+    handler_add_libdir share
+    require slurm-handler
+
+    files_load_config --optional cluster-slurm
+    export cw_CLUSTER_SLURM_config="${cw_CLUSTER_SLURM_config:-"${cw_ROOT}"/opt/slurm/etc/slurm.conf}"
+    handler_tee main "$@"

--- a/cluster-slurm/share/add-node
+++ b/cluster-slurm/share/add-node
@@ -5,6 +5,9 @@
 ## Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
 ##
 ################################################################################
+
+. $(dirname ${BASH_SOURCE[-1]})/common
+
 name="$(echo "$1" | cut -f1 -d.)"
 slots="$2"
 state="$3"
@@ -12,20 +15,21 @@ state="$3"
 tmpfile1="$(mktemp /tmp/cluster-slurm.add-node.XXXXXXXX)"
 tmpfile2="$(mktemp /tmp/cluster-slurm.add-node.XXXXXXXX)"
 
-mkdir -p "${cw_ROOT}"/var/lock
-exec 9> "${cw_ROOT}"/var/lock/cluster-slurm.lock && flock -w30 9
-grep -v "^NodeName=" "${cw_CLUSTER_SLURM_config}" > "${tmpfile1}"
-# if NodeName line already exists for this node, remove it first
-grep "^NodeName=" "${cw_CLUSTER_SLURM_config}" | grep -v "^NodeName=${name} " > "${tmpfile2}"
-if [ "$state" ]; then
-    echo "NodeName=${name} CPUs=${slots} State=${state}" >> "${tmpfile2}"
-else
-    echo "NodeName=${name} CPUs=${slots}" >> "${tmpfile2}"
+if _lock; then
+  echo "Adding node ${name} with ${slots} CPUs"
+  grep -v "^NodeName=" "${cw_CLUSTER_SLURM_config}" > "${tmpfile1}"
+  # if NodeName line already exists for this node, remove it first
+  grep "^NodeName=" "${cw_CLUSTER_SLURM_config}" | grep -v "^NodeName=${name} " > "${tmpfile2}"
+  if [ "$state" ]; then
+      echo "NodeName=${name} CPUs=${slots} State=${state}" >> "${tmpfile2}"
+  else
+      echo "NodeName=${name} CPUs=${slots}" >> "${tmpfile2}"
+  fi
+  # sort list
+  sort "${tmpfile2}" >> "${tmpfile1}"
+  # recreate slurm.conf
+  cat "${tmpfile1}" > "${cw_CLUSTER_SLURM_config}"
+  _unlock
 fi
-# sort list
-sort "${tmpfile2}" >> "${tmpfile1}"
-# recreate slurm.conf
-cat "${tmpfile1}" > "${cw_CLUSTER_SLURM_config}"
-exec 9>&-
 
 rm -f "${tmpfile1}" "${tmpfile2}"

--- a/cluster-slurm/share/add-node-to-partition
+++ b/cluster-slurm/share/add-node-to-partition
@@ -21,8 +21,7 @@ tmpfile="$(mktemp /tmp/cluster-slurm.add-node-to-partition.XXXXXXXX)"
 
 if _lock; then
   echo "Adding node $hostname to partition $group"
-  sed -i -e "s/\(PartitionName=$group .*\)Nodes=\([^ ]*\) \(.*\)/\1 Nodes=$hostname,\2 \3" \
-         -e "s/,(null)//" \
+  sed -i -e "s/\(PartitionName=$group .*\)Nodes=\([^ ]*\) \(.*\)/\1 Nodes=$hostname,\2 \3/" \
          "${cw_CLUSTER_SLURM_config}"
   _unlock
 else

--- a/cluster-slurm/share/add-node-to-partition
+++ b/cluster-slurm/share/add-node-to-partition
@@ -20,6 +20,7 @@ group="$2"
 
 if _lock; then
   nodeline=$(scontrol show PartitionName="$group" | grep -e " Nodes=.*" | sed -e "s/Nodes=\(.*\)/Nodes=$hostname,\1/" -e "s/,(null)//")
+  echo "[debug] About to run: scontrol update PartitionName=\"$group\" ${nodeline}"
   scontrol update PartitionName="$group" ${nodeline}
   _rewrite_config
   _unlock

--- a/cluster-slurm/share/add-node-to-partition
+++ b/cluster-slurm/share/add-node-to-partition
@@ -12,15 +12,7 @@ module purge
 module use "${cw_ROOT}"/etc/modules
 module load services/slurm
 
-_lock() {
-    mkdir -p "${cw_ROOT}"/var/lock
-    exec 9> "${cw_ROOT}"/var/lock/cluster-slurm.lock && flock -w30 9
-}
-
-_unlock() {
-    exec 9>&-
-}
-
+. common
 
 hostname="$(echo "$1" | cut -f1 -d.)"
 group="$2"
@@ -29,5 +21,8 @@ group="$2"
 if _lock; then
   nodeline=$(scontrol show PartitionName="$group" | grep -e " Nodes=.*" | sed -e "s/Nodes=\(.*\)/Nodes=$hostname,\1/" -e "s/,(null)//")
   scontrol update PartitionName="$group" ${nodeline}
+  _rewrite_config
+  _unlock
+else
+  echo "Could not obtain lock; can't update partition"
 fi
-_unlock

--- a/cluster-slurm/share/add-node-to-partition
+++ b/cluster-slurm/share/add-node-to-partition
@@ -12,7 +12,7 @@ module purge
 module use "${cw_ROOT}"/etc/modules
 module load services/slurm
 
-. common
+. $(dirname ${BASH_SOURCE[-1]})/common
 
 hostname="$(echo "$1" | cut -f1 -d.)"
 group="$2"

--- a/cluster-slurm/share/add-node-to-partition
+++ b/cluster-slurm/share/add-node-to-partition
@@ -20,13 +20,13 @@ tmpfile="$(mktemp /tmp/cluster-slurm.add-node-to-partition.XXXXXXXX)"
 
 
 if _lock; then
-  log "Adding node $hostname to partition $group"
+  echo "Adding node $hostname to partition $group"
   sed -i -e "s/\(PartitionName=$group .*\)Nodes=\([^ ]*\) \(.*\)/\1 Nodes=$hostname,\2 \3" \
          -e "s/,(null)//" \
          "${cw_CLUSTER_SLURM_config}"
   _unlock
 else
-  log "Could not obtain lock; can't update partition"
+  echo "Could not obtain lock; can't update partition"
 fi
 
 rm -f "$tmpfile"

--- a/cluster-slurm/share/add-node-to-partition
+++ b/cluster-slurm/share/add-node-to-partition
@@ -1,0 +1,33 @@
+#!/bin/bash
+################################################################################
+##
+## Alces Clusterware - Handler support script
+## Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+##
+################################################################################
+
+. /etc/profile.d/alces-clusterware.sh
+. /etc/xdg/clusterware/config.vars.sh
+module purge
+module use "${cw_ROOT}"/etc/modules
+module load services/slurm
+
+_lock() {
+    mkdir -p "${cw_ROOT}"/var/lock
+    exec 9> "${cw_ROOT}"/var/lock/cluster-slurm.lock && flock -w30 9
+}
+
+_unlock() {
+    exec 9>&-
+}
+
+
+hostname="$(echo "$1" | cut -f1 -d.)"
+group="$2"
+
+
+if _lock; then
+  nodeline=$(scontrol show PartitionName="$group" | grep -e " Nodes=.*" | sed -e "s/Nodes=\(.*\)/Nodes=$hostname,\1/" -e "s/,(null)//")
+  scontrol update PartitionName="$group" ${nodeline}
+fi
+_unlock

--- a/cluster-slurm/share/add-node-to-partition
+++ b/cluster-slurm/share/add-node-to-partition
@@ -21,7 +21,7 @@ tmpfile="$(mktemp /tmp/cluster-slurm.add-node-to-partition.XXXXXXXX)"
 
 if _lock; then
   echo "Adding node $hostname to partition $group"
-  sed -i -e "s/\(PartitionName=$group .*\)Nodes=\([^ ]*\) \(.*\)/\1 Nodes=$hostname,\2 \3/" \
+  sed -i -e "s/\(PartitionName=$group .*\)Nodes=\([^ ]*\)\(.*\)/\1 Nodes=$hostname,\2 \3/" \
          "${cw_CLUSTER_SLURM_config}"
   _unlock
 else

--- a/cluster-slurm/share/add-node-to-partition
+++ b/cluster-slurm/share/add-node-to-partition
@@ -6,12 +6,6 @@
 ##
 ################################################################################
 
-. /etc/profile.d/alces-clusterware.sh
-. /etc/xdg/clusterware/config.vars.sh
-module purge
-module use "${cw_ROOT}"/etc/modules
-module load services/slurm
-
 . $(dirname ${BASH_SOURCE[-1]})/common
 
 hostname="$(echo "$1" | cut -f1 -d.)"

--- a/cluster-slurm/share/add-node-to-partition
+++ b/cluster-slurm/share/add-node-to-partition
@@ -16,14 +16,17 @@ module load services/slurm
 
 hostname="$(echo "$1" | cut -f1 -d.)"
 group="$2"
+tmpfile="$(mktemp /tmp/cluster-slurm.add-node-to-partition.XXXXXXXX)"
 
 
 if _lock; then
-  nodeline=$(scontrol show PartitionName="$group" | grep -e " Nodes=.*" | sed -e "s/Nodes=\(.*\)/Nodes=$hostname,\1/" -e "s/,(null)//")
-  echo "[debug] About to run: scontrol update PartitionName=\"$group\" ${nodeline}"
-  scontrol update PartitionName="$group" ${nodeline}
-  _rewrite_config
+  log "Adding node $hostname to partition $group"
+  sed -i -e "s/\(PartitionName=$group .*\)Nodes=\([^ ]*\) \(.*\)/\1 Nodes=$hostname,\2 \3" \
+         -e "s/,(null)//" \
+         "${cw_CLUSTER_SLURM_config}"
   _unlock
 else
-  echo "Could not obtain lock; can't update partition"
+  log "Could not obtain lock; can't update partition"
 fi
+
+rm -f "$tmpfile"

--- a/cluster-slurm/share/add-partition-if-not-exist
+++ b/cluster-slurm/share/add-partition-if-not-exist
@@ -20,6 +20,7 @@ maxsize="$2"
 
 if ! sinfo -o "%R" -a | grep "$name"; then
   if _lock; then
+    echo "[debug] about to run: scontrol create PartitionName=\"$name\""
     scontrol create PartitionName="$name"
     _rewrite_config
     _unlock

--- a/cluster-slurm/share/add-partition-if-not-exist
+++ b/cluster-slurm/share/add-partition-if-not-exist
@@ -21,7 +21,8 @@ maxsize="$2"
 if ! sinfo -o "%R" -a | grep "$name"; then
   if _lock; then
     echo "Creating new partition $name"
-    echo "PartitionName=$name Nodes=" >> "${cw_CLUSTER_SLURM_config}"
+    # Slurm docs lie; we need a trailing comma after empty nodelist for it to be valid
+    echo "PartitionName=$name Nodes=," >> "${cw_CLUSTER_SLURM_config}"
     _unlock
   else
     echo "Could not obtain lock; can't add partition"

--- a/cluster-slurm/share/add-partition-if-not-exist
+++ b/cluster-slurm/share/add-partition-if-not-exist
@@ -20,10 +20,10 @@ maxsize="$2"
 
 if ! sinfo -o "%R" -a | grep "$name"; then
   if _lock; then
-    log "Creating new partition $name"
+    echo "Creating new partition $name"
     echo "PartitionName=$name Nodes=" >> "${cw_CLUSTER_SLURM_config}"
     _unlock
   else
-    log "Could not obtain lock; can't add partition"
+    echo "Could not obtain lock; can't add partition"
   fi
 fi

--- a/cluster-slurm/share/add-partition-if-not-exist
+++ b/cluster-slurm/share/add-partition-if-not-exist
@@ -12,15 +12,7 @@ module purge
 module use "${cw_ROOT}"/etc/modules
 module load services/slurm
 
-_lock() {
-    mkdir -p "${cw_ROOT}"/var/lock
-    exec 9> "${cw_ROOT}"/var/lock/cluster-slurm.lock && flock -w30 9
-}
-
-_unlock() {
-    exec 9>&-
-}
-
+. common
 
 name="$1"
 maxsize="$2"
@@ -29,7 +21,9 @@ maxsize="$2"
 if ! sinfo -o "%R" -a | grep "$name"; then
   if _lock; then
     scontrol create PartitionName="$name"
+    _rewrite_config
+    _unlock
+  else
+    echo "Could not obtain lock; can't add partition"
   fi
-_unlock
-
 fi

--- a/cluster-slurm/share/add-partition-if-not-exist
+++ b/cluster-slurm/share/add-partition-if-not-exist
@@ -6,6 +6,12 @@
 ##
 ################################################################################
 
+. /etc/profile.d/alces-clusterware.sh
+. /etc/xdg/clusterware/config.vars.sh
+module purge
+module use "${cw_ROOT}"/etc/modules
+module load services/slurm
+
 . $(dirname ${BASH_SOURCE[-1]})/common
 
 name="$1"

--- a/cluster-slurm/share/add-partition-if-not-exist
+++ b/cluster-slurm/share/add-partition-if-not-exist
@@ -20,11 +20,10 @@ maxsize="$2"
 
 if ! sinfo -o "%R" -a | grep "$name"; then
   if _lock; then
-    echo "[debug] about to run: scontrol create PartitionName=\"$name\""
-    scontrol create PartitionName="$name"
-    _rewrite_config
+    log "Creating new partition $name"
+    echo "PartitionName=$name Nodes=" >> "${cw_CLUSTER_SLURM_config}"
     _unlock
   else
-    echo "Could not obtain lock; can't add partition"
+    log "Could not obtain lock; can't add partition"
   fi
 fi

--- a/cluster-slurm/share/add-partition-if-not-exist
+++ b/cluster-slurm/share/add-partition-if-not-exist
@@ -1,0 +1,35 @@
+#!/bin/bash
+################################################################################
+##
+## Alces Clusterware - Handler support script
+## Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+##
+################################################################################
+
+. /etc/profile.d/alces-clusterware.sh
+. /etc/xdg/clusterware/config.vars.sh
+module purge
+module use "${cw_ROOT}"/etc/modules
+module load services/slurm
+
+_lock() {
+    mkdir -p "${cw_ROOT}"/var/lock
+    exec 9> "${cw_ROOT}"/var/lock/cluster-slurm.lock && flock -w30 9
+}
+
+_unlock() {
+    exec 9>&-
+}
+
+
+name="$1"
+maxsize="$2"
+
+
+if ! sinfo -o "%R" -a | grep "$name"; then
+  if _lock; then
+    scontrol create PartitionName="$name"
+  fi
+_unlock
+
+fi

--- a/cluster-slurm/share/add-partition-if-not-exist
+++ b/cluster-slurm/share/add-partition-if-not-exist
@@ -6,12 +6,6 @@
 ##
 ################################################################################
 
-. /etc/profile.d/alces-clusterware.sh
-. /etc/xdg/clusterware/config.vars.sh
-module purge
-module use "${cw_ROOT}"/etc/modules
-module load services/slurm
-
 . $(dirname ${BASH_SOURCE[-1]})/common
 
 name="$1"

--- a/cluster-slurm/share/add-partition-if-not-exist
+++ b/cluster-slurm/share/add-partition-if-not-exist
@@ -12,7 +12,7 @@ module purge
 module use "${cw_ROOT}"/etc/modules
 module load services/slurm
 
-. common
+. $(dirname ${BASH_SOURCE[-1]})/common
 
 name="$1"
 maxsize="$2"

--- a/cluster-slurm/share/common
+++ b/cluster-slurm/share/common
@@ -1,0 +1,26 @@
+#!/bin/bash
+################################################################################
+##
+## Alces Clusterware - Handler support functions
+## Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+##
+################################################################################
+
+_lock() {
+    mkdir -p "${cw_ROOT}"/var/lock
+    exec 9> "${cw_ROOT}"/var/lock/cluster-slurm.lock && flock -w30 9
+}
+
+_unlock() {
+    exec 9>&-
+}
+
+_rewrite_config() {
+  # Other parts of processing directly modify the Slurm config file and trigger
+  # a reload of slurmctld. In order that our changes here not be overwritten,
+  # we ask Slurm to write a copy of its (in-memory) config and then use that to
+  # overwrite the on-disk config file.
+  local tempconfig
+  tempconfig=$(scontrol write config | cut -f5 -d' ')
+  cp "$tempconfig" "${cw_CLUSTER_SLURM_config}"
+}

--- a/cluster-slurm/share/common
+++ b/cluster-slurm/share/common
@@ -22,5 +22,5 @@ _rewrite_config() {
   # overwrite the on-disk config file.
   local tempconfig
   tempconfig=$(scontrol write config | cut -f5 -d' ')
-  cp "$tempconfig" "${cw_CLUSTER_SLURM_config}"
+  cat "$tempconfig" | sed -e "/CpuFreqDef=Unknown/d" > "${cw_CLUSTER_SLURM_config}"
 }

--- a/cluster-slurm/share/common
+++ b/cluster-slurm/share/common
@@ -14,13 +14,3 @@ _lock() {
 _unlock() {
     exec 9>&-
 }
-
-_rewrite_config() {
-  # Other parts of processing directly modify the Slurm config file and trigger
-  # a reload of slurmctld. In order that our changes here not be overwritten,
-  # we ask Slurm to write a copy of its (in-memory) config and then use that to
-  # overwrite the on-disk config file.
-  local tempconfig
-  tempconfig=$(scontrol write config | cut -f5 -d' ')
-  cat "$tempconfig" | sed -e "/CpuFreqDef=Unknown/d" > "${cw_CLUSTER_SLURM_config}"
-}

--- a/cluster-slurm/share/prune-node
+++ b/cluster-slurm/share/prune-node
@@ -10,7 +10,13 @@ tmpfile="$(mktemp /tmp/cluster-slurm.add-node.XXXXXXXX)"
 
 mkdir -p "${cw_ROOT}"/var/lock
 exec 9> "${cw_ROOT}"/var/lock/cluster-slurm.lock && flock -w30 9
+
+# Remove the node's entry line
 grep -v "^NodeName=${name} " "${cw_CLUSTER_SLURM_config}" > "${tmpfile}"
+
+# Remove from any partitions' node lists too
+sed -i -r -e "s/(Nodes.*)([=,])${name}(,)?/\1\2/" "$tmpfile"
+
 cat "${tmpfile}" > "${cw_CLUSTER_SLURM_config}"
 exec 9>&-
 

--- a/cluster-slurm/share/prune-node
+++ b/cluster-slurm/share/prune-node
@@ -16,7 +16,7 @@ if _lock; then
   grep -v "^NodeName=${name} " "${cw_CLUSTER_SLURM_config}" > "${tmpfile}"
 
   # Remove from any partitions' node lists too
-  sed -i -r -e "s/(Nodes.*)([=,])${name}(,)?/\1\2/" "$tmpfile"
+  sed -i -r -e "s/(Nodes.*)([=,])${name}(,)?/\1\2/" -e "s/(Nodes.*),,[[:space:]]*/\1/" "$tmpfile"
 
   cat "${tmpfile}" > "${cw_CLUSTER_SLURM_config}"
   rm -f "${tmpfile}"

--- a/cluster-slurm/share/prune-node
+++ b/cluster-slurm/share/prune-node
@@ -5,19 +5,23 @@
 ## Copyright (C) 2016 Stephen F. Norledge and Alces Software Ltd.
 ##
 ################################################################################
-name="$(echo "$1" | cut -f1 -d.)"
-tmpfile="$(mktemp /tmp/cluster-slurm.add-node.XXXXXXXX)"
 
-mkdir -p "${cw_ROOT}"/var/lock
-exec 9> "${cw_ROOT}"/var/lock/cluster-slurm.lock && flock -w30 9
+. $(dirname ${BASH_SOURCE[-1]})/common
 
-# Remove the node's entry line
-grep -v "^NodeName=${name} " "${cw_CLUSTER_SLURM_config}" > "${tmpfile}"
+if _lock; then
+  name="$(echo "$1" | cut -f1 -d.)"
+  tmpfile="$(mktemp /tmp/cluster-slurm.add-node.XXXXXXXX)"
 
-# Remove from any partitions' node lists too
-sed -i -r -e "s/(Nodes.*)([=,])${name}(,)?/\1\2/" "$tmpfile"
+  # Remove the node's entry line
+  grep -v "^NodeName=${name} " "${cw_CLUSTER_SLURM_config}" > "${tmpfile}"
 
-cat "${tmpfile}" > "${cw_CLUSTER_SLURM_config}"
-exec 9>&-
+  # Remove from any partitions' node lists too
+  sed -i -r -e "s/(Nodes.*)([=,])${name}(,)?/\1\2/" "$tmpfile"
 
-rm -f "${tmpfile}"
+  cat "${tmpfile}" > "${cw_CLUSTER_SLURM_config}"
+  rm -f "${tmpfile}"
+
+  _unlock
+else
+  echo "Locking failed; unable to prune node"
+fi


### PR DESCRIPTION
This PR adds support for multiple autoscaling groups using the Slurm scheduler.

- An implementation of `autoscaling-member-join` is provided for Slurm.
- AWS scale-out calculations now no longer expect separate `byslot` and `bynode` demand values, since these are SGE-specific concepts.
- `prune-node` now also removes departing nodes from partition membership.

Related PR: https://github.com/alces-software/clusterware-services/pull/32