### PR TITLE
Misc improvements to job queues

### DIFF
--- a/cluster-customizer/libexec/customize/actions/job-queue-actions/get-output
+++ b/cluster-customizer/libexec/customize/actions/job-queue-actions/get-output
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 
 main() {
     local queue job_file job_id output_file
@@ -37,6 +38,7 @@ main() {
 }
 
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    process_reexec_sudo "$@"
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require job-queue
 

--- a/cluster-customizer/libexec/customize/actions/job-queue-actions/list-jobs
+++ b/cluster-customizer/libexec/customize/actions/job-queue-actions/list-jobs
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 
 main() {
     local queue
@@ -35,6 +36,7 @@ main() {
 }
 
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    process_reexec_sudo "$@"
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require job-queue
 

--- a/cluster-customizer/libexec/customize/actions/job-queue-actions/list-output
+++ b/cluster-customizer/libexec/customize/actions/job-queue-actions/list-output
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 
 main() {
     local queue job_id
@@ -36,6 +37,7 @@ main() {
 }
 
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    process_reexec_sudo "$@"
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require job-queue
 

--- a/cluster-customizer/libexec/customize/actions/job-queue-actions/list-queues
+++ b/cluster-customizer/libexec/customize/actions/job-queue-actions/list-queues
@@ -22,8 +22,10 @@
 #==============================================================================
 require action
 require handler
+require process
 
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    process_reexec_sudo "$@"
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require job-queue
 

--- a/cluster-customizer/libexec/customize/actions/job-queue-actions/put
+++ b/cluster-customizer/libexec/customize/actions/job-queue-actions/put
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 
 main() {
     local queue job_file job_id
@@ -44,6 +45,7 @@ main() {
 }
 
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    process_reexec_sudo "$@"
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require job-queue
 

--- a/cluster-customizer/libexec/customize/actions/job-queue-actions/rm
+++ b/cluster-customizer/libexec/customize/actions/job-queue-actions/rm
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 
 main() {
     local queue job_id
@@ -36,6 +37,7 @@ main() {
 }
 
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    process_reexec_sudo "$@"
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require job-queue
 

--- a/cluster-customizer/libexec/customize/actions/job-queue-actions/status
+++ b/cluster-customizer/libexec/customize/actions/job-queue-actions/status
@@ -22,6 +22,7 @@
 #==============================================================================
 require action
 require handler
+require process
 
 main() {
     local queue job_id
@@ -36,6 +37,7 @@ main() {
 }
 
 if [ -d "${cw_ROOT}"/etc/handlers/cluster-customizer/share ]; then
+    process_reexec_sudo "$@"
     handler_add_libdir "${cw_ROOT}"/etc/handlers/cluster-customizer/share
     require job-queue
 

--- a/cluster-customizer/share/job-queue.functions.sh
+++ b/cluster-customizer/share/job-queue.functions.sh
@@ -109,6 +109,7 @@ job_queue_save_job_output() {
     # about python-magic not being available.
 
     "${cw_ROOT}"/opt/s3cmd/s3cmd put --recursive \
+        --acl-public \
         --default-mime-type=text/plain \
         --guess-mime-type \
         --no-mime-magic \

--- a/cluster-customizer/share/job-queue.functions.sh
+++ b/cluster-customizer/share/job-queue.functions.sh
@@ -114,6 +114,11 @@ job_queue_save_job_output() {
         --no-mime-magic \
         $(job_queue_work_dir_path "${queue}" "${output_dir}"/"${job_id}"/"$(hostname)") \
         $(job_queue_bucket_path "${queue}" "${output_dir}"/"${job_id}")/
+
+    mkdir -p /var/log/clusterware/prime-continuous-delivery/
+    rsync -a $(job_queue_work_dir_path "${queue}" "${output_dir}"/) \
+        /var/log/clusterware/prime-continuous-delivery/"${output_dir}"/
+
 }
 
 # If there are any objects already stored with job_id, the job is invalid.  We

--- a/cluster-customizer/share/job-queue.functions.sh
+++ b/cluster-customizer/share/job-queue.functions.sh
@@ -98,7 +98,20 @@ job_queue_save_job_output() {
     job_id=$2
     output_dir=$3
 
-    "${cw_ROOT}"/opt/s3cmd/s3cmd put --quiet --recursive \
+    # python-magic isn't installed on our clusters by default and without it
+    # the results files are uploaded as binary/octet-stream, which breaks
+    # viewing the logs in a browser tab.
+    #
+    # Most of the files should be text/plain, so we use that as the default
+    # and try to get s3cmd to use the file extension for guessing others.
+    #
+    # Using `--no-mime-magic` prevents the logs from filling with warnings
+    # about python-magic not being available.
+
+    "${cw_ROOT}"/opt/s3cmd/s3cmd put --recursive \
+        --default-mime-type=text/plain \
+        --guess-mime-type \
+        --no-mime-magic \
         $(job_queue_work_dir_path "${queue}" "${output_dir}"/"${job_id}"/"$(hostname)") \
         $(job_queue_bucket_path "${queue}" "${output_dir}"/"${job_id}")/
 }


### PR DESCRIPTION
 - Allow job-queue functionality to be run via `sudo`.
 - Silence the `Module python-magic is not available...` warning.
 - Store a copy of the logs locally.
 - Upload the files with the correct mime-types.

Discussion of whether to upload the files as publicly readable, is currently ongoing.