### PR TITLE
Job queue README improvements

### DIFF
--- a/cluster-customizer/JOB_QUEUE_README.md
+++ b/cluster-customizer/JOB_QUEUE_README.md
@@ -8,10 +8,24 @@ file and executed.  It will be called with two arguments:
  1. the role of the instance executing the job
  2. the cluster's name.
 
-As the Clusterware periodic cronjob is only installed on the master node, the
-jobs will only be run on the master node.  If the Clusterware periodic cronjob
-is installed on multiple nodes, a single node in the cluster will execute the
-job.
+Currently customizer queue jobs for a cluster will be picked up from
+`s3://${customizer_bucket}/customizer/${customizer_name}` when the Clusterware
+periodic cronjob runs, where `$customizer_bucket` refers to the customizer
+bucket for the account (e.g. `alces-flight-nmi0ztdmyzm3ztm3`), and
+`$customizer_name` refers to any customizer profile name (e.g.
+`prime-continuous-delivery` or `domain-dev.alces.network`).
+
+Within each such folder, a particular cluster with name `$cluster_name` will
+process any scripts in `job-queue.d/${cluster_name}/pending`.  One way to add
+scripts to a queue for a cluster is to manually upload them to the appropriate
+folder; another way is to use the `alces customize job-queue put
+$customizer_name $script`, which will upload the given `$script` to the
+`$customizer_name` customizer profile queue for that cluster.
+
+Note that currently jobs will only be run on the master node for a cluster.
+However, multiple clusters with the same name in different domains for an
+account will currently all pick up and process the same job, unless one cluster
+completes processing it before another picks it up.
 
 The results of running the job are stored on s3 with the following prefix:
 `s3://${customizer_bucket}/customizer/${customizer_name}/job-queue.d/${cluster_name}`.

--- a/cluster-customizer/JOB_QUEUE_README.md
+++ b/cluster-customizer/JOB_QUEUE_README.md
@@ -9,14 +9,16 @@ file and executed.  It will be called with two arguments:
  2. the cluster's name.
 
 Currently customizer queue jobs for a cluster will be picked up from
-`s3://${customizer_bucket}/customizer/${customizer_name}` when the Clusterware
-periodic cronjob runs, where `$customizer_bucket` refers to the customizer
-bucket for the account (e.g. `alces-flight-nmi0ztdmyzm3ztm3`), and
-`$customizer_name` refers to any customizer profile name (e.g.
-`prime-continuous-delivery` or `domain-dev.alces.network`).
+`s3://${customizer_bucket}/customizer/${customizer_name}` (referred from here
+in this document as `$customizer_profile`) when the Clusterware periodic
+cronjob runs, where `$customizer_bucket` refers to the customizer bucket for
+the account (e.g. `alces-flight-nmi0ztdmyzm3ztm3`), and `$customizer_name`
+refers to any customizer profile name (e.g.  `prime-continuous-delivery` or
+`domain-dev.alces.network`).
 
-Within each such folder, a particular cluster with name `$cluster_name` will
-process any scripts in `job-queue.d/${cluster_name}/pending`.  One way to add
+For each such customizer profile, a particular cluster with name
+`$cluster_name` will process any scripts in
+`$customizer_profile/job-queue.d/${cluster_name}/pending`. One way to add
 scripts to a queue for a cluster is to manually upload them to the appropriate
 folder; another way is to use the `alces customize job-queue put
 $customizer_name $script`, which will upload the given `$script` to the
@@ -28,15 +30,14 @@ account will currently all pick up and process the same job, unless one cluster
 completes processing it before another picks it up.
 
 The results of running the job are stored on s3 with the following prefix:
-`s3://${customizer_bucket}/customizer/${customizer_name}/job-queue.d/${cluster_name}`.
-Specifically, output will be available at `${prefix}/completed/${job_id}/logs`
-and its exit code will be available at `${prefix}/completed/${job_id}/status.`
+`$customizer_profile/job-queue.d/${cluster_name}`. Specifically, output will
+be available at `${prefix}/completed/${job_id}/logs` and its exit code will be
+available at `${prefix}/completed/${job_id}/status.`
 
 ## Custom job runners
 
-It is possible to customize a job queue with an alternate job running
-strategy.  To do so create the file:
-`s3://${customizer_bucket}/customizer/${customizer_name}/share/process-job`.
+It is possible to customize a job queue with an alternate job running strategy.
+To do so create the file: `$customizer_profile/share/process-job`.
 
 When a node executes a job, instead of executing the job script directly, it
 will execute the `process-job` script.  The `process-job` script will be called
@@ -110,8 +111,7 @@ way, one may wish to validate ensure that the job script is valid before
 running it.  This can be done by writing a custom job validator for the job
 queue customizer.
 
-The custom job validator resides at
-`s3://${customizer_bucket}/customizer/${customizer_name}/share/validate-job`.
+The custom job validator resides at `$customizer_profile/share/validate-job`.
 It will be called with two arguments:
 
  1. the path to the job file to validate,

--- a/cluster-customizer/JOB_QUEUE_README.md
+++ b/cluster-customizer/JOB_QUEUE_README.md
@@ -1,4 +1,4 @@
-# Custom job validators and job runners for alces customize job-queue
+# Custom job validators and job runners for `alces customize job-queue`
 
 ## Default job running
 
@@ -24,8 +24,8 @@ It is possible to customize a job queue with an alternate job running
 strategy.  To do so create the file:
 `s3://${customizer_bucket}/customizer/${customizer_name}/share/process-job`.
 
-When a node executes a job, instead executing the job script directly, it will
-execute the `process-job` script.  The `process-job` script will be called
+When a node executes a job, instead of executing the job script directly, it
+will execute the `process-job` script.  The `process-job` script will be called
 with 4 arguments:
 
  1. the path to the job script to run
@@ -33,9 +33,9 @@ with 4 arguments:
  3. the role of the instance executing the job
  4. the cluster's name.
 
-Possible uses of custom job runners include, creating additional output files,
-interpretting the job script in some non-standard manner, running the the
-job script in a non-standard location.
+Possible uses of custom job runners include: creating additional output files,
+interpreting the job script in some non-standard manner, running the job script
+in a non-standard location.
 
 An example job runner which creates some additional output files and runs the
 job file in the standard manner is shown below.
@@ -68,9 +68,9 @@ operation=install
 package=ffmpeg
 ```
 
-For this job script, the job runner should use a package manager to install
-the package ffmpeg.  The following, is a simple custom job runner which would
-do just that.
+For this job script, the job runner should use a package manager to install the
+package `ffmpeg`.  The following is a simple custom job runner which would do
+just that.
 
 ```bash
 main () {


### PR DESCRIPTION
A few tweaks/additions to the job queue READMEs I've made while investigating whether this feature will be the best choice for the Monitor appliance stuff I'm working on, to expand the current explanation and check my understanding of the feature.

@benarmston - thanks for documenting/linking me to this, it's been very useful for better understanding the feature. If you want to check over my changes for accuracy when you get a chance that would be great :slightly_smiling_face:.

@mjtko - we noticed https://github.com/alces-software/clusterware-handlers/compare/develop...dev/job-queue-readme-improvements?expand=1#diff-c370d73f3cfd3b8217115c222a078350R28 yesterday, is this likely to be an issue that needs documenting/fixing at some point?