### PR TITLE
Support customizer feature sets in default repo

### DIFF
--- a/cluster-customizer/configure
+++ b/cluster-customizer/configure
@@ -47,6 +47,7 @@ main() {
 
     if [ ! -f "${cw_ROOT}/etc/cluster-customizer/config.yml" ]; then
       if files_load_config --optional instance-aws config/cluster; then
+        files_load_config cluster-customizer
         if [[ "$cw_CLUSTER_CUSTOMIZER_feature_set" ]]; then
           _SET_PREFIX="${cw_CLUSTER_CUSTOMIZER_feature_set}/"  # Note trailing slash
         fi

--- a/cluster-customizer/configure
+++ b/cluster-customizer/configure
@@ -47,12 +47,17 @@ main() {
 
     if [ ! -f "${cw_ROOT}/etc/cluster-customizer/config.yml" ]; then
       if files_load_config --optional instance-aws config/cluster; then
+        if [[ "$cw_CLUSTER_CUSTOMIZER_feature_set" ]]; then
+          _SET_PREFIX="${cw_CLUSTER_CUSTOMIZER_feature_set}/"  # Note trailing slash
+        fi
         sed -e "s/_REGION_/${cw_INSTANCE_aws_region:-eu-west-1}/" \
             -e "s/_AWS_ACCOUNT_HASH_/${cw_INSTANCE_aws_account_hash}/" \
+            -e "s/_SET_PREFIX_/${_SET_PREFIX}/" \
           "${dir}/etc/cluster-customizer/config.yml" > "${cw_ROOT}/etc/cluster-customizer/config.yml"
       else
         sed -e "s/_REGION_/eu-west-1/" \
             -e "/_AWS_ACCOUNT_HASH_/d" \
+            -e "s/_SET_PREFIX_//" \
           "${dir}/etc/cluster-customizer/config.yml" > "${cw_ROOT}/etc/cluster-customizer/config.yml"
       fi
     fi

--- a/cluster-customizer/configure
+++ b/cluster-customizer/configure
@@ -53,7 +53,7 @@ main() {
         fi
         sed -e "s/_REGION_/${cw_INSTANCE_aws_region:-eu-west-1}/" \
             -e "s/_AWS_ACCOUNT_HASH_/${cw_INSTANCE_aws_account_hash}/" \
-            -e "s/_SET_PREFIX_/${_SET_PREFIX}/" \
+            -e "s#_SET_PREFIX_#${_SET_PREFIX}#" \
           "${dir}/etc/cluster-customizer/config.yml" > "${cw_ROOT}/etc/cluster-customizer/config.yml"
       else
         sed -e "s/_REGION_/eu-west-1/" \

--- a/cluster-customizer/etc/cluster-customizer/config.yml
+++ b/cluster-customizer/etc/cluster-customizer/config.yml
@@ -1,4 +1,4 @@
 profiles: []
 repositories:
-  feature: "s3://alces-flight-profiles-_REGION_/features"
+  feature: "s3://alces-flight-profiles-_REGION_/_SET_PREFIX_features"
   account: "s3://alces-flight-_AWS_ACCOUNT_HASH_/customizer"


### PR DESCRIPTION
This PR changes the initial setup of the customizer `config.yml` file to use the value of `$cw_CLUSTER_CUSTOMIZER_feature_set`, if set, in the default repository URL for the `feature` repository.