### PR TITLE
Fix job queues not running

### DIFF
--- a/cluster-customizer/event-periodic
+++ b/cluster-customizer/event-periodic
@@ -37,6 +37,7 @@ setup() {
 }
 
 main() {
+    files_load_config instance config/cluster # Provides `cw_INSTANCE_role`.
     customize_run_hooks event-periodic | log_blob /var/log/clusterware/customizer-periodic-events.log
     if [ "${cw_INSTANCE_role}" == "master" ] ; then
         job_queue_process_queues "$@" | log_blob /var/log/clusterware/job-queue.log
@@ -44,6 +45,7 @@ main() {
 }
 
 setup
+require files
 require handler
 require customize
 require job-queue


### PR DESCRIPTION
At some point recently the variable `cw_INSTANCE_role`, used to determine if this node should process job queues, has become undefined when this script is executed (though presumably was defined in the past when this executed as this used to work); this therefore caused job queues to never be processed by nodes as the condition would never be true.

Explicitly loading the config file defining this variable appears to fix this. Presumably the file was being loaded via some dependency somehow before, and this has since changed. I had a look but couldn't see an obvious cause of this, possibly this is related to the recent Customizers refactoring or additions?