### PR TITLE
Running job queue jobs on any node

### DIFF
--- a/cluster-customizer/event-periodic
+++ b/cluster-customizer/event-periodic
@@ -42,11 +42,8 @@ setup() {
 }
 
 main() {
-    files_load_config instance config/cluster # Provides `cw_INSTANCE_role`.
     customize_run_hooks event-periodic | log_blob /var/log/clusterware/customizer-periodic-events.log
-    if [ "${cw_INSTANCE_role}" == "master" ] ; then
-        job_queue_process_queues "$@" | log_blob /var/log/clusterware/job-queue.log
-    fi
+    job_queue_process_queues "$@" | log_blob /var/log/clusterware/job-queue.log
 }
 
 setup


### PR DESCRIPTION
This PR is a supporting change for https://github.com/alces-software/clusterware-services/pull/41. 

We now upload job queue jobs with the node the job is intended for included in the folder name, in order to allow running jobs on any node by querying the appropriate folder. In order to process jobs on other nodes we also need to remove this check that the current node is the master node.