### PR TITLE
Removed VPN user login box instructions

### DIFF
--- a/cluster-vpn/configure
+++ b/cluster-vpn/configure
@@ -63,6 +63,12 @@ main() {
             echo "cw_CLUSTER_VPN_access_password=\"${password}\"" >> "${cw_ROOT}"/etc/cluster-vpn.rc
 
             "${cw_ROOT}"/libexec/share/www-add-resource "${dir}"/var/alces-flight-www/vpn
+
+            files_load_config cluster-vpn
+            if [ "${cw_CLUSTER_VPN_auth:-cert}" == "pam" ]; then
+                sed -i "${cw_ROOT}"/var/lib/alces-flight-www/flight/vpn/index.html \
+                    -e 's/<!--%PAM-ENABLED%//g' -e 's/%PAM-ENABLED%-->//g'
+            fi
             ln -s "${cw_ROOT}"/etc/openvpn/client "${cw_ROOT}/var/lib/alces-flight-www/flight/vpn/downloads"
         fi
     fi

--- a/cluster-vpn/var/alces-flight-www/vpn/htdocs/index.html
+++ b/cluster-vpn/var/alces-flight-www/vpn/htdocs/index.html
@@ -254,15 +254,6 @@
                   <p style="text-align: center;">
                     <img style="max-width: 600px; width: 75%;" src="img/windows-config-select.png">
                   </p>
-                  <p>
-                    Your client system will show the connection window as it contacts the
-                    VPN server and makes the connection; if prompted, enter the username
-                    and password you use to access your cluster to connect to the VPN
-                    service.
-                  </p>
-                  <p style="text-align: center;">
-                    <img style="max-width: 600px; width: 75%;" src="img/windows-connect.png">
-                  </p>
                 </div>
                 <div class="col-lg-12">
                   <h3><i class="fa fa-apple"></i> Connecting from macOS</h3>

--- a/cluster-vpn/var/alces-flight-www/vpn/htdocs/index.html
+++ b/cluster-vpn/var/alces-flight-www/vpn/htdocs/index.html
@@ -254,6 +254,7 @@
                   <p style="text-align: center;">
                     <img style="max-width: 600px; width: 75%;" src="img/windows-config-select.png">
                   </p>
+                  <!--%PAM-ENABLED%
                   <p>
                     Your client system will show the connection window as it contacts the
                     VPN server and makes the connection; if prompted, enter the username
@@ -263,6 +264,7 @@
                   <p style="text-align: center;">
                     <img style="max-width: 600px; width: 75%;" src="img/windows-connect.png">
                   </p>
+                  %PAM-ENABLED%-->
                 </div>
                 <div class="col-lg-12">
                   <h3><i class="fa fa-apple"></i> Connecting from macOS</h3>

--- a/cluster-vpn/var/alces-flight-www/vpn/htdocs/index.html
+++ b/cluster-vpn/var/alces-flight-www/vpn/htdocs/index.html
@@ -254,6 +254,15 @@
                   <p style="text-align: center;">
                     <img style="max-width: 600px; width: 75%;" src="img/windows-config-select.png">
                   </p>
+                  <p>
+                    Your client system will show the connection window as it contacts the
+                    VPN server and makes the connection; if prompted, enter the username
+                    and password you use to access your cluster to connect to the VPN
+                    service.
+                  </p>
+                  <p style="text-align: center;">
+                    <img style="max-width: 600px; width: 75%;" src="img/windows-connect.png">
+                  </p>
                 </div>
                 <div class="col-lg-12">
                   <h3><i class="fa fa-apple"></i> Connecting from macOS</h3>


### PR DESCRIPTION
User login details are not prompted for when making a VPN connection, instructions are therefore outdated. _(note: understandable if wanting to keep this data in considering "if prompted" implies this is a slight possibility and may be worth leaving in?)_