### PR TITLE
Include admin user in Gridware user whitelist

### DIFF
--- a/cluster-gridware/configure
+++ b/cluster-gridware/configure
@@ -126,7 +126,7 @@ _install_docker_ssl_cert() {
 }
 
 main() {
-    local admin_uid admin_user
+    local admin_uid
 
     files_load_config gridware
 
@@ -159,12 +159,11 @@ main() {
 
     # add admin user to gridware group
     admin_uid=$(grep "^UID_MIN " /etc/login.defs | awk '{ print $2 };')
-    admin_user=$(id -gn ${admin_uid:-1000})
-    usermod -G gridware -a "$admin_user"
+    usermod -G gridware -a "$(id -gn ${admin_uid:-1000})"
     # and add them to Gridware's userspace whitelist
     cat <<EOF >${cw_GRIDWARE_root}${cw_GRIDWARE_root}/etc/whitelist.yml
 users:
-- $admin_user
+- $(id -un ${admin_uid:-1000})
 EOF
 }
 

--- a/cluster-gridware/configure
+++ b/cluster-gridware/configure
@@ -162,7 +162,7 @@ main() {
     usermod -G gridware -a "$(id -gn ${admin_uid:-1000})"
     # and add them to Gridware's userspace whitelist
     cat <<EOF >${cw_GRIDWARE_root}/etc/whitelist.yml
-users:
+:users:
 - $(id -un ${admin_uid:-1000})
 EOF
 }

--- a/cluster-gridware/configure
+++ b/cluster-gridware/configure
@@ -126,7 +126,7 @@ _install_docker_ssl_cert() {
 }
 
 main() {
-    local admin_uid
+    local admin_uid admin_user
 
     files_load_config gridware
 
@@ -159,7 +159,13 @@ main() {
 
     # add admin user to gridware group
     admin_uid=$(grep "^UID_MIN " /etc/login.defs | awk '{ print $2 };')
-    usermod -G gridware -a "$(id -gn ${admin_uid:-1000})"
+    admin_user=$(id -gn ${admin_uid:-1000})
+    usermod -G gridware -a "$admin_user"
+    # and add them to Gridware's userspace whitelist
+    cat <<EOF >${cw_GRIDWARE_root}${cw_GRIDWARE_root}/etc/whitelist.yml
+users:
+- $admin_user
+EOF
 }
 
 setup

--- a/cluster-gridware/configure
+++ b/cluster-gridware/configure
@@ -161,7 +161,7 @@ main() {
     admin_uid=$(grep "^UID_MIN " /etc/login.defs | awk '{ print $2 };')
     usermod -G gridware -a "$(id -gn ${admin_uid:-1000})"
     # and add them to Gridware's userspace whitelist
-    cat <<EOF >${cw_GRIDWARE_root}${cw_GRIDWARE_root}/etc/whitelist.yml
+    cat <<EOF >${cw_GRIDWARE_root}/etc/whitelist.yml
 users:
 - $(id -un ${admin_uid:-1000})
 EOF


### PR DESCRIPTION
This PR adds the cluster admin user (by default, the one with UID `1000`) to the Gridware users whitelist, allowing them to install distro dependencies for Gridware packages without needing to go through the approval steps.

Related PRs:
 - `gridware`: https://github.com/alces-software/gridware/pull/17
 - `clusterware-services`: https://github.com/alces-software/clusterware-services/pull/58